### PR TITLE
replaced os.rename with shutil.move in sqlite.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The versions coincide with releases on pip. Only major versions will be released
 
 ## [development](https://github.com/singularityware/singularity-python/tree/development) (development)
  - added support to select client based on uri (e.g., `SREGISTRY_CLIENT=hub` maps to `hub://`
+ - changed os.rename to shutil.move in order to support moving files between directories that are located in different volumes. 
+
 
 ## [0.0.6](https://pypi.python.org/pypi/sregistry/0.0.6) (0.0.6)
  - added base client for Docker, and Nvidia Container Registry
@@ -40,3 +42,4 @@ The versions coincide with releases on pip. Only major versions will be released
  - addition of (mostly complete) documentation, Changelog, and Singularity file
  - this is the initial creation of just the singularity registry client, to be separate from
 singularity python.
+

--- a/sregistry/database/sqlite.py
+++ b/sregistry/database/sqlite.py
@@ -38,6 +38,7 @@ from glob import glob
 import os
 import json
 import sys
+import shutil
 
 
 # COLLECTIONS ##################################################################
@@ -269,7 +270,7 @@ def add(self, image_path=None,
         if copy is True:
             copyfile(image_path, storage_path)
         else:
-            os.rename(image_path, storage_path)
+            shutil.move(image_path, storage_path)
 
         image_path = storage_path
 

--- a/sregistry/main/docker/api.py
+++ b/sregistry/main/docker/api.py
@@ -30,6 +30,7 @@ import os
 import json
 import re
 import sys
+import shutil
 
 
 ###############################################################################
@@ -348,7 +349,7 @@ def get_layer(self, image_id, repo_name, download_folder=None):
     tar_download = self.download(url, file_name)
 
     try:
-        os.rename(tar_download, download_folder)
+        shutil.move(tar_download, download_folder)
     except Exception:
         msg = "Cannot untar layer %s," % tar_download
         msg += " was there a problem with download?"

--- a/sregistry/main/workers/tasks.py
+++ b/sregistry/main/workers/tasks.py
@@ -60,7 +60,7 @@ def download_task(url, headers, destination, download_type='layer'):
     tar_download = download(url, file_name, headers=headers)
 
     try:
-        os.rename(tar_download, destination)
+        shutil.move(tar_download, destination)
     except Exception:
         msg = "Cannot untar layer %s," % tar_download
         msg += " was there a problem with download?"


### PR DESCRIPTION
In case the current directory where sregistry pull is run from is in a different file system with the directory set with SREGISTRY_STORAGE then os.rename does not work. shutil.move will work. 