### PR TITLE
Remove/sqlalchemy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [development](https://github.com/singularityware/singularity-python/tree/development) (development)
- - fixing bug with pull that not available to client for registry (0.0.63) (development)
+ - removing sqlalchemy dependency, so user can optionally install database with client (0.0.64) (development)
+ - fixing bug with pull that not available to client for registry (0.0.63)
  - changed os.rename to shutil.move to support moving files between different filesystems (0.0.62)
  - better consolidated dependencies, most just required for singularity registry client
  - added support to select client based on uri (e.g., `SREGISTRY_CLIENT=hub` maps to `hub://` (0.0.61)

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ Importantly, the Singularity Global Client does not have any dependency on Docke
 [![asciicast](https://asciinema.org/a/154519.png)](https://asciinema.org/a/154519?speed=4)
 
 ## Getting Started
- - [Installation](install): quick steps to get up and running with the Singularity Registry Global Client. This includes a local installation, or the option to use a Singularity image.
+ - [Installation](install): quick steps to get up and running with the Singularity Registry Global Client. This includes a local installation, or the option to use a Singularity image. You also have the option to install a "basic" client (meaning just moving images) or a client and storage (a local sqlachemy database).
  - [Global Commands](commands): While most clients support the same functions (e.g., `pull`) there are a few global commands that, given that they interact with the local user environment consistently across remote resources, are found regardless of the endpoint you connect to. This getting started guide will go through the basic usage for the local client, meaning functions that you can use to manage, inspect, and otherwise interact with images and metadata locally.
 
 ## Available Clients

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -136,6 +136,12 @@ the SRegistry database, then export `SREGISTRY_DISABLE=yes`.
 The `sregistry` client exposes a lot of customization through environment variables, so you as the user have the power to configure it exactly as you need, or stick to defaults that are reasonably set. In these sections, we will review the sets of environment variables for you to use. If you are a developer, see our [client contribution guide](/sregistry-cli/contribute-client) for details on interacting with these environment variables.
 
 
+#### Http and Authentication
+While most of the authentication variables live with the clients, `sregistry` offers a few Global settings to be applied to all web requests.
+
+ - **SREGISTRY_HTTPS_NOVERIFY** will [set verify to False](http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification) when you are making a request, and this means that the server you are using sregistry against has https enabled, but is using an untrusted (usually self-signed) certificate. This option should not be used in production, but is generally useful if you are working with a test server, or are debugging commands. See the [original issue](https://github.com/singularityhub/sregistry-cli/issues/56) for more details. Generally, we do not recommend that you use this more than occasionally. The server certificate in question should be added to your trusted certificates file.
+
+
 #### Database and Storage
 The database refers to the sqlite3 file used to store metadata, typically in the user's home, and the storage refers to the actual folder of images. You can control this behavior with the following environment variables.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -24,6 +24,16 @@ cd sregistry-cli
 python setup.py install
 ```
 
+And you can also install from pip:
+
+```
+# Client and Database
+pip install sregistry[all]
+
+# Client only
+pip install sregistry[all-basic]
+```
+
 Given that the current endpoints are limited, you will do ok with the above 
 method. However, when the time comes to install specific modules, you would do
 that by specifying the ones you want, e.g.,

--- a/docs/install.md
+++ b/docs/install.md
@@ -48,6 +48,49 @@ pip install sregistry[myclient]
 
 For now, it's probably fastest and easiest to use the Singularity image.
 
+# Clients Available
+Singularity Registry Global Client is developed to give you maximum flexibility to install only what you need. For this, you have many different options for installing the software. if you use the above method, you will install the full client and storage, meaning that you can push and pull images to many different clients (Google vs. Singularity Registry) and you can keep a local database file for keeping track of your images. However, it might be that you want to install dependencies for just one client. Remember for all of the pip commands below, you can install with a local repository, or remote.
+
+```
+# Local repository
+pip install -e .[myclient]
+
+# From pypi
+pip install [myclient]
+```
+
+And here are your options.
+
+## Clients and Storage
+The first set includes `sqlalchemy` so that you can manage a local database of images across clients.
+```
+# Singularity Registry
+pip install sregistry[registry]
+
+# Google Storage
+pip install sregistry[google-storage]
+
+# Google Drive
+pip install sregistry[google-drive]
+```
+
+## Clients Only
+These do **not** include `sqlalchemy`, meaning you can push and pull, but that's it. There is no database to add records to or store metadata in. 
+
+```
+# Singularity Registry
+pip install sregistry[registry-basic]
+
+# Google Storage
+pip install sregistry[google-storage-basic]
+
+# Google Drive
+pip install sregistry[google-drive-basic]
+```
+
+Clients for Singularity Hub and Nvidia are not detailed here as they don't require additional library dependencies.
+
+
 # Singularity
 To build a singularity container
 

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ def get_lookup():
 
 
 # Read in requirements
-def get_requirements(lookup=None, key='INSTALL_REQUIRES'):
-    '''get_requirements reads in requirements and versions from
+def get_reqs(lookup=None, key='INSTALL_REQUIRES'):
+    '''get requirements, mean reading in requirements and versions from
     the lookup obtained with get_lookup'''
 
     if lookup == None:
@@ -66,13 +66,25 @@ with open('README.md') as filey:
 
 if __name__ == "__main__":
 
-    INSTALL_REQUIRES = get_requirements(lookup)
-    INSTALL_REQUIRES_ALL = get_requirements(lookup,'INSTALL_REQUIRES_ALL')
-    DROPBOX = get_requirements(lookup,'INSTALL_REQUIRES_DROPBOX')
-    REGISTRY = get_requirements(lookup,'INSTALL_REQUIRES_REGISTRY')
-    GLOBUS = get_requirements(lookup,'INSTALL_REQUIRES_GLOBUS')
-    GOOGLE_STORAGE = get_requirements(lookup,'INSTALL_REQUIRES_GOOGLE_STORAGE')
-    GOOGLE_DRIVE = get_requirements(lookup,'INSTALL_REQUIRES_GOOGLE_DRIVE')
+    INSTALL_REQUIRES = get_reqs(lookup)
+
+    # These requirement DON'T include sqlalchemy, only client
+
+    INSTALL_BASIC_ALL = get_reqs(lookup,'INSTALL_BASIC_ALL')
+    DROPBOX_BASIC = get_reqs(lookup,'INSTALL_BASIC_DROPBOX')
+    REGISTRY_BASIC = get_reqs(lookup,'INSTALL_BASIC_REGISTRY')
+    GLOBUS_BASIC = get_reqs(lookup,'INSTALL_BASIC_GLOBUS')
+    GOOGLE_STORAGE_BASIC = get_reqs(lookup,'INSTALL_BASIC_GOOGLE_STORAGE')
+    GOOGLE_DRIVE_BASIC = get_reqs(lookup,'INSTALL_BASIC_GOOGLE_DRIVE')
+
+    # These requirement sets include sqlalchemy, for client+storage
+
+    INSTALL_REQUIRES_ALL = get_reqs(lookup,'INSTALL_REQUIRES_ALL')
+    DROPBOX = get_reqs(lookup,'INSTALL_REQUIRES_DROPBOX')
+    REGISTRY = get_reqs(lookup,'INSTALL_REQUIRES_REGISTRY')
+    GLOBUS = get_reqs(lookup,'INSTALL_REQUIRES_GLOBUS')
+    GOOGLE_STORAGE = get_reqs(lookup,'INSTALL_REQUIRES_GOOGLE_STORAGE')
+    GOOGLE_DRIVE = get_reqs(lookup,'INSTALL_REQUIRES_GOOGLE_DRIVE')
 
     setup(name=NAME,
           version=VERSION,
@@ -90,12 +102,21 @@ if __name__ == "__main__":
           keywords=KEYWORDS,
           install_requires = INSTALL_REQUIRES,
           extras_require={
+
+              'dropbox-basic': [DROPBOX_BASIC],
+              'globus-basic': [GLOBUS_BASIC],
+              'registry-basic': [REGISTRY_BASIC],
+              'google-storage-basic': [GOOGLE_STORAGE_BASIC],
+              'google-drive-basic': [GOOGLE_DRIVE_BASIC],
+              'all-basic': [INSTALL_BASIC_ALL],
+
               'dropbox': [DROPBOX],
               'globus': [GLOBUS],
               'registry': [REGISTRY],
               'google-storage': [GOOGLE_STORAGE],
               'google-drive': [GOOGLE_DRIVE],
               'all': [INSTALL_REQUIRES_ALL]
+
           },
           classifiers=[
               'Intended Audience :: Science/Research',

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,6 @@ if __name__ == "__main__":
               'google-storage-basic': [GOOGLE_STORAGE_BASIC],
               'google-drive-basic': [GOOGLE_DRIVE_BASIC],
               'all-basic': [INSTALL_BASIC_ALL],
-
               'dropbox': [DROPBOX],
               'globus': [GLOBUS],
               'registry': [REGISTRY],

--- a/sregistry/database/__init__.py
+++ b/sregistry/database/__init__.py
@@ -1,8 +1,13 @@
-from .models import *
-from .sqlite import ( 
-    add, get, rm, rmi, images, 
-    inspect,
-    get_container,
-    get_collection,
-    get_or_create_collection 
-)
+from sregistry.defaults import SREGISTRY_DATABASE
+
+if SREGISTRY_DATABASE is None:
+    from .dummy import ( add, init_db )
+else:
+    from .models import *
+    from .sqlite import ( 
+        add, get, rm, rmi, images, 
+        inspect,
+        get_container,
+        get_collection,
+        get_or_create_collection 
+    )

--- a/sregistry/database/dummy.py
+++ b/sregistry/database/dummy.py
@@ -53,7 +53,7 @@ def add(self, image_path=None,
 
     # First check that we don't have one already!
     class container:
-        name=name=names['image']
+        name=names['image']
         tag=names['tag']
         image=image_path
         client=self.client_name

--- a/sregistry/database/dummy.py
+++ b/sregistry/database/dummy.py
@@ -1,0 +1,64 @@
+'''
+
+Copyright (C) 2017-2018 The Board of Trustees of the Leland Stanford Junior
+University.
+Copyright (C) 2017-2018 Vanessa Sochat.
+
+This program is free software: you can redistribute it and/or modify it
+under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or (at your
+option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+'''
+
+from sregistry.logger import bot
+from sregistry.utils import ( 
+    parse_image_name, 
+    remove_uri
+)
+import os
+import sys
+
+
+def add(self, image_path=None,
+              image_name=None,
+              url=None,
+              metadata=None,
+              save=True, 
+              copy=False):
+
+    '''dummy add simple returns an object that mimics a database entry, so the
+       calling function (in push or pull) can interact with it equally. Most 
+       variables (other than image_path) are not used.'''
+
+    # We can only save if the image is provided
+    if image_path is not None:
+        if not os.path.exists(image_path):
+            bot.error('Cannot find %s' %image_path)
+            sys.exit(1)
+
+    if image_name is None:
+        bot.error('You must provide an image uri <collection>/<namespace>')
+        sys.exit(1)
+    names = parse_image_name( remove_uri(image_name) )
+    bot.debug('Added %s to filesystem' % names['uri'])    
+
+    # First check that we don't have one already!
+    class container:
+        name=name=names['image']
+        tag=names['tag']
+        image=image_path
+        client=self.client_name
+        url=url
+        uri=names['uri']
+
+    bot.info("[container][%s] %s" % (action,names['uri']))
+    return container

--- a/sregistry/database/dummy.py
+++ b/sregistry/database/dummy.py
@@ -62,3 +62,11 @@ def add(self, image_path=None,
 
     bot.info("[container][%s] %s" % (action,names['uri']))
     return container
+
+
+def init_db(self, db_path=None):
+    '''initialize the database, meaning we just set the name to be dummy
+    '''
+
+    # Database Setup, use default if uri not provided
+    self.database = 'dummy'

--- a/sregistry/defaults.py
+++ b/sregistry/defaults.py
@@ -71,7 +71,7 @@ USERHOME = pwd.getpwuid(os.getuid())[5]
 DISABLE_CACHE = convert2boolean(getenv("SINGULARITY_DISABLE_CACHE", False))
 DISABLE_DATABASE = convert2boolean(getenv("SREGISTRY_DISABLE", False))
 SREGISTRY_CLIENT = getenv("SREGISTRY_CLIENT", "hub")
-
+DISABLE_SSL_CHECK = convert2boolean(getenv("SREGISTRY_HTTPS_NOVERIFY", False))
 
 #########################
 # Fun Settings

--- a/sregistry/defaults.py
+++ b/sregistry/defaults.py
@@ -97,6 +97,13 @@ SREGISTRY_DATABASE = None
 SREGISTRY_STORAGE = None
 SREGISTRY_BASE = None
 
+# If sqlalchemy isn't installed, user doesn't have support for database
+try:
+    from sqlalchemy import or_
+except ImportError:
+    DISABLE_DATABASE = True
+
+
 # If the user didn't disable caching or the database
 if not DISABLE_CACHE and DISABLE_DATABASE is False:
 

--- a/sregistry/main/__init__.py
+++ b/sregistry/main/__init__.py
@@ -102,8 +102,9 @@ def get_client(image=None):
 
     # If no database, import dummy functions that return the equivalent
     else:
-        from sregistry.database.dummy import ( add )
+        from sregistry.database import ( add, init_db )
         Client.add = add
+        Client._init_db = init_db        
 
     # Initialize the database
     cli = Client()

--- a/sregistry/main/__init__.py
+++ b/sregistry/main/__init__.py
@@ -100,6 +100,11 @@ def get_client(image=None):
         Client.get_container = get_container
         Client.get_collection = get_collection
 
+    # If no database, import dummy functions that return the equivalent
+    else:
+        from sregistry.database.dummy import ( add )
+        Client.add = add
+
     # Initialize the database
     cli = Client()
 

--- a/sregistry/main/base/__init__.py
+++ b/sregistry/main/base/__init__.py
@@ -33,8 +33,8 @@ from sregistry.main.base.headers import (
 )
 
 from sregistry.main.base.http import ( 
-    call, delete, download, get, 
-    paginate_get, post, put, stream
+    call, delete, download, get, paginate_get, 
+    post, put, stream, verify
 )
 
 from sregistry.main.base.settings import (
@@ -125,3 +125,4 @@ ApiConnection._paginate_get = paginate_get
 ApiConnection._post = post
 ApiConnection._put = put
 ApiConnection._stream = stream
+ApiConnection._verify = verify

--- a/sregistry/main/base/http.py
+++ b/sregistry/main/base/http.py
@@ -107,13 +107,10 @@ def verify(self):
     '''
     from sregistry.defaults import DISABLE_SSL_CHECK
 
-    verify = not DISABLE_SSL_CHECK
-
-    # Give warning, if disabled
-    if verify is False:
+    if DISABLE_SSL_CHECK is True:
         bot.warning('Verify of certificates disabled! ::TESTING USE ONLY::')
 
-    return verify
+    return not DISABLE_SSL_CHECK
 
 
 def download(self, url, file_name, headers=None, show_progress=True):

--- a/sregistry/main/base/http.py
+++ b/sregistry/main/base/http.py
@@ -24,7 +24,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from requests.exceptions import HTTPError
 
 from sregistry.logger import bot
-from sregistry.defaults import DISABLE_SSL_CHECK
 import shutil
 import requests
 import tempfile
@@ -99,6 +98,24 @@ def paginate_get(self, url, headers=None, return_json=True, start_page=None):
     return results
         
 
+def verify(self):
+    '''
+       verify will return a True or False to determine to verify the
+       requests call or not. If False, we should the user a warning message,
+       as this should not be done in production!
+
+    '''
+    from sregistry.defaults import DISABLE_SSL_CHECK
+
+    verify = not DISABLE_SSL_CHECK
+
+    # Give warning, if disabled
+    if verify is False:
+        bot.warning('Verify of certificates disabled! ::TESTING USE ONLY::')
+
+    return verify
+
+
 def download(self, url, file_name, headers=None, show_progress=True):
     '''stream to a temporary file, rename on successful completion
 
@@ -110,8 +127,10 @@ def download(self, url, file_name, headers=None, show_progress=True):
     '''
 
     fd, tmp_file = tempfile.mkstemp(prefix=("%s.tmp." % file_name)) 
-    verify = not DISABLE_SSL_CHECK
     os.close(fd)
+
+    # Should we verify the request?
+    verify = self._verify()
 
     # Check here if exists
     if requests.head(url, verify=verify).status_code in [200, 401]:
@@ -132,6 +151,8 @@ def stream(self, url, headers=None, stream_to=None, retry=True):
 
     bot.debug("GET %s" %url)
 
+
+
     # Ensure headers are present, update if not
     if headers == None:
         if self.headers is None:
@@ -140,7 +161,7 @@ def stream(self, url, headers=None, stream_to=None, retry=True):
 
     response = requests.get(url,         
                             headers=headers,
-                            verify=not DISABLE_SSL_CHECK,
+                            verify=self._verify(),
                             stream=True)
 
     # Deal with token if necessary
@@ -207,7 +228,7 @@ def call(self, url, func, data=None, headers=None,
     response = func(url=url,
                     headers=heads,
                     data=data,
-                    verify=not DISABLE_SSL_CHECK,
+                    verify=self._verify(),
                     stream=stream)
 
     # Errored response, try again with refresh

--- a/sregistry/main/base/http.py
+++ b/sregistry/main/base/http.py
@@ -24,6 +24,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from requests.exceptions import HTTPError
 
 from sregistry.logger import bot
+from sregistry.defaults import DISABLE_SSL_CHECK
 import shutil
 import requests
 import tempfile
@@ -109,10 +110,11 @@ def download(self, url, file_name, headers=None, show_progress=True):
     '''
 
     fd, tmp_file = tempfile.mkstemp(prefix=("%s.tmp." % file_name)) 
+    verify = not DISABLE_SSL_CHECK
     os.close(fd)
 
     # Check here if exists
-    if requests.head(url).status_code in [200, 401]:
+    if requests.head(url, verify=verify).status_code in [200, 401]:
         response = self._stream(url,headers=headers,stream_to=tmp_file)
 
         if isinstance(response, HTTPError):
@@ -138,6 +140,7 @@ def stream(self, url, headers=None, stream_to=None, retry=True):
 
     response = requests.get(url,         
                             headers=headers,
+                            verify=not DISABLE_SSL_CHECK,
                             stream=True)
 
     # Deal with token if necessary
@@ -204,6 +207,7 @@ def call(self, url, func, data=None, headers=None,
     response = func(url=url,
                     headers=heads,
                     data=data,
+                    verify=not DISABLE_SSL_CHECK,
                     stream=stream)
 
     # Errored response, try again with refresh

--- a/sregistry/main/workers/tasks.py
+++ b/sregistry/main/workers/tasks.py
@@ -19,6 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
+from sregistry.defaults import DISABLE_SSL_CHECK
 from requests.exceptions import HTTPError
 
 from sregistry.logger import bot
@@ -116,8 +117,11 @@ def download(url, file_name, headers=None, show_progress=True):
     fd, tmp_file = tempfile.mkstemp(prefix=("%s.tmp." % file_name)) 
     os.close(fd)
 
+    if DISABLE_SSL_CHECK is True:
+        bot.warning('Verify of certificates disabled! ::TESTING USE ONLY::')
+
     # Check here if exists
-    if requests.head(url).status_code in [200, 401]:
+    if requests.head(url, verify=DISABLE_SSL_CHECK).status_code in [200, 401]:
         response = stream(url,headers=headers,stream_to=tmp_file)
 
         if isinstance(response, HTTPError):
@@ -137,9 +141,13 @@ def stream(url, headers, stream_to=None, retry=True):
 
     bot.debug("GET %s" %url)
 
+    if DISABLE_SSL_CHECK is True:
+        bot.warning('Verify of certificates disabled! ::TESTING USE ONLY::')
+
     # Ensure headers are present, update if not
     response = requests.get(url,         
                             headers=headers,
+                            verify=not DISABLE_SSL_CHECK,
                             stream=True)
 
     # Deal with token if necessary
@@ -193,6 +201,9 @@ def call(url, func, data=None, headers=None,
     return_json: return json if successful
     '''
  
+    if DISABLE_SSL_CHECK is True:
+        bot.warning('Verify of certificates disabled! ::TESTING USE ONLY::')
+
     if data is not None:
         if not isinstance(data,dict):
             data = json.dumps(data)
@@ -200,6 +211,7 @@ def call(url, func, data=None, headers=None,
     response = func(url=url,
                     headers=headers,
                     data=data,
+                    verify=not DISABLE_SSL_CHECK,
                     stream=stream)
 
     # Errored response, try again with refresh

--- a/sregistry/main/workers/tasks.py
+++ b/sregistry/main/workers/tasks.py
@@ -120,8 +120,10 @@ def download(url, file_name, headers=None, show_progress=True):
     if DISABLE_SSL_CHECK is True:
         bot.warning('Verify of certificates disabled! ::TESTING USE ONLY::')
 
-    # Check here if exists
-    if requests.head(url, verify=DISABLE_SSL_CHECK).status_code in [200, 401]:
+    verify = not DISABLE_SSL_CHECK
+
+    # Does the url being requested exist?
+    if requests.head(url, verify=verify).status_code in [200, 401]:
         response = stream(url,headers=headers,stream_to=tmp_file)
 
         if isinstance(response, HTTPError):

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -62,7 +62,7 @@ INSTALL_BASIC_GOOGLE_STORAGE = (
 
 INSTALL_BASIC_GOOGLE_DRIVE = (
     ('oauth2client', {'min_version': '3.0'}),
-    ('google-api-python-client', {'min_version': '1.6.4'}),
+    ('google-api-python-client', {'min_version': '1.6.4'})
 )
 
 INSTALL_BASIC_ALL = (INSTALL_REQUIRES +
@@ -77,18 +77,18 @@ INSTALL_BASIC_ALL = (INSTALL_REQUIRES +
 
 INSTALL_REQUIRES_GLOBUS = (
     ('sqlalchemy', {'min_version': None}),
-    ('globus-sdk[jwt]', {'exact_version': '1.3.0'}),
+    ('globus-sdk[jwt]', {'exact_version': '1.3.0'})
 )
 
 INSTALL_REQUIRES_REGISTRY = (
     ('requests-toolbelt', {'exact_version': '0.8.0'}),
     ('dateutils', {'min_version': "0.6.6"}),
-    ('python-dateutil', {'min_verison': "2.5.3"})
+    ('python-dateutil', {'min_verison': "2.5.3"}),
     ('sqlalchemy', {'min_version': None})
 )
 
 INSTALL_REQUIRES_DROPBOX = (
-    ('sqlalchemy', {'min_version': None})
+    ('sqlalchemy', {'min_version': None}),
 )
 
 INSTALL_REQUIRES_GOOGLE_STORAGE = (
@@ -101,7 +101,7 @@ INSTALL_REQUIRES_GOOGLE_STORAGE = (
 INSTALL_REQUIRES_GOOGLE_DRIVE = (
     ('oauth2client', {'min_version': '3.0'}),
     ('sqlalchemy', {'min_version': None}),
-    ('google-api-python-client', {'min_version': '1.6.4'}),
+    ('google-api-python-client', {'min_version': '1.6.4'})
 )
 
 INSTALL_REQUIRES_ALL = (INSTALL_REQUIRES +

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -19,7 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.0.62"
+__version__ = "0.0.63"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'
@@ -28,15 +28,55 @@ KEYWORDS = 'singularity containers registry hub'
 DESCRIPTION = "Command line tool for working with singularity-hub and registry."
 LICENSE = "LICENSE"
 
+################################################################################
+# Global requirements
+
+
 INSTALL_REQUIRES = (
     ('requests', {'exact_version': '2.18.4'}),
     ('pygments', {'min_version': '2.1.3'}),
-    ('sqlalchemy', {'min_version': None})
 )
 
-# Submodule Requirements
+################################################################################
+# Submodule Requirements (no database, just client)
+
+
+INSTALL_BASIC_GLOBUS = (
+    ('globus-sdk[jwt]', {'exact_version': '1.3.0'}),
+)
+
+INSTALL_BASIC_REGISTRY = (
+    ('requests-toolbelt', {'exact_version': '0.8.0'}),
+    ('dateutils', {'min_version': "0.6.6"}),
+    ('python-dateutil', {'min_verison': "2.5.3"})
+)
+
+INSTALL_BASIC_DROPBOX = (
+)
+
+INSTALL_BASIC_GOOGLE_STORAGE = (
+    ('oauth2client', {'min_version': '3.0'}),
+    ('google-cloud-storage', {'min_version': '1.4.0'}),
+    ('retrying', {'exact_version': '1.3.3'}),
+)
+
+INSTALL_BASIC_GOOGLE_DRIVE = (
+    ('oauth2client', {'min_version': '3.0'}),
+    ('google-api-python-client', {'min_version': '1.6.4'}),
+)
+
+INSTALL_BASIC_ALL = (INSTALL_REQUIRES +
+                     INSTALL_BASIC_DROPBOX + 
+                     INSTALL_BASIC_REGISTRY +
+                     INSTALL_BASIC_GOOGLE_STORAGE +
+                     INSTALL_BASIC_GOOGLE_DRIVE)
+
+################################################################################
+# Submodule Requirements (versions that include database)
+
 
 INSTALL_REQUIRES_GLOBUS = (
+    ('sqlalchemy', {'min_version': None}),
     ('globus-sdk[jwt]', {'exact_version': '1.3.0'}),
 )
 
@@ -44,19 +84,23 @@ INSTALL_REQUIRES_REGISTRY = (
     ('requests-toolbelt', {'exact_version': '0.8.0'}),
     ('dateutils', {'min_version': "0.6.6"}),
     ('python-dateutil', {'min_verison': "2.5.3"})
+    ('sqlalchemy', {'min_version': None})
 )
 
 INSTALL_REQUIRES_DROPBOX = (
+    ('sqlalchemy', {'min_version': None})
 )
 
 INSTALL_REQUIRES_GOOGLE_STORAGE = (
     ('oauth2client', {'min_version': '3.0'}),
     ('google-cloud-storage', {'min_version': '1.4.0'}),
     ('retrying', {'exact_version': '1.3.3'}),
+    ('sqlalchemy', {'min_version': None})
 )
 
 INSTALL_REQUIRES_GOOGLE_DRIVE = (
     ('oauth2client', {'min_version': '3.0'}),
+    ('sqlalchemy', {'min_version': None}),
     ('google-api-python-client', {'min_version': '1.6.4'}),
 )
 

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -19,7 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.0.63"
+__version__ = "0.0.64"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'


### PR DESCRIPTION
This will remove the sqlalchemy dependency, meaning users can install sregistry to *just* use the client to move images (but not initialize or interact with a database). This is in response to https://github.com/singularityware/singularity-python/issues/87, the plan is to fully integrate the client functions here, and then to be able to remove them entirely from singularity python (which should specialize for more singularity hub functions and not the clients for image management).

@dctrud here is something to start our conversation. The way I want it to work is that the user can choose to install any of the current options, but instead now with a `--basic` suffix, and doing this skips installation of sqlalchemy. When the client fires up, given that there is an environment variable set to disable it OR now if the sqlalchemy module isn't found (the case when you don't install it) it should create clients that don't do anything with a database. To work with this, I had to add a "dummy" function (e.g. add) that would still return an object that looks like what would be returned by the equivalent function (after adding to the database, for example).

This is quick and rough (and not tested!) but I wanted to get you something to look at soon.