### PR TITLE
[utils.recipes] fix

### DIFF
--- a/sregistry/utils/recipes.py
+++ b/sregistry/utils/recipes.py
@@ -29,6 +29,8 @@ def parse_header(recipe, header="from", remove_header=True):
     '''
     parsed_header = None
     fromline = [x for x in recipe.split('\n') if "%s:" %header in x.lower()]
+    if len(fromline) == 0:
+        return ""
     if len(fromline) > 0:
         fromline = fromline[0]
         parsed_header = fromline.strip()


### PR DESCRIPTION
Function parse_header in utils.recipes threw an "AttributeError: 'list' object has no attribute 'split' when recipe has no line containing "from:". Changed it to return an empty string instead.