### PR TITLE
Add Google Container Registry (gcr.io)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.0.x)
+ - support for gcr.io, and future "special" token names (0.0.68)
  - adding move (mv) command so client can update database with new path (0.0.67)
  - adding rename command, which renames image in storage (and w/o path assumes name there)
  - fixing bug with Docker and Nvidia pull to clean up temporary sandbox build folders

--- a/docs/clients/README.md
+++ b/docs/clients/README.md
@@ -12,6 +12,7 @@ Singularity Registry Global client has tutorials and walkthroughs for the follow
  - [Global Commands](/sregistry-cli/commands): commands for all clients.
  - [Docker Hub](/sregistry-cli/client-docker): interact with layers to build images from Docker Hub
  - [Dropbox](/sregistry-cli/client-dropbox): interact with images stored in Dropbox
+ - [Google Container Registry](/sregistry-cli/client-gcr): the same as docker. Here are tricks for authenticating if you have trouble.
  - [Google Storage](/sregistry-cli/client-google-storage): interact with images from Google Storage
  - [Google Drive](/sregistry-cli/client-google-drive): interact with images from Google Drive
  - [Nvidia Container Registry](/sregistry-cli/client-nvidia): Nvidia Container registry serves Docker images

--- a/docs/clients/gcr.md
+++ b/docs/clients/gcr.md
@@ -1,0 +1,42 @@
+---
+layout: default
+title: Google Container Cloud
+pdf: true
+permalink: /client-gcr
+toc: false
+---
+
+# Singularity Global Client: Google Container Cloud
+
+These sections will detail of how to connect with the Google Container Cloud using the Singularity Global client. The backend here is actually the same as [docker](/sregistry-cli/client-docker), and the authentication is slightly different. We won't go over every call here (see the Docker pages for the rest) but we will show you how to authenticate here.
+
+## Using GCloud
+If you are familiar with the gcloud client, you might know that when you are logged in, you can use a command like this to pull an image:
+
+```
+gcloud docker -- pull gcr.io/deepvariant-docker/deepvariant:0.5.0
+```
+
+The sregistry equivalent would then be:
+
+```
+sregistry pull docker://gcr.io/deepvariant-docker/deepvariant:0.5.0
+```
+
+If you have a docker config.json on your computer, this command might be sufficient! If not, then you will want to try setting the following environment variables.
+
+
+```
+SREGISTRY_DOCKERHUB_USERNAME='_token'
+SREGISTRY_DOCKERHUB_BASE="gcr.io"
+SREGISTRY_DOCKERHUB_PASSWORD='mysecretpass'
+export SREGISTRY_DOCKERHUB_PASSWORD SREGISTRY_DOCKERHUB_BASE SREGISTRY_DOCKERHUB_USERNAME
+```
+
+Then you should be able to pull the image, and proceed using the client via the standard [docker commands](/sregistry-cli/client-docker). Continue reading there to see them.
+
+
+<div>
+    <a href="/sregistry-cli/client-dropbox"><button class="previous-button btn btn-primary"><i class="fa fa-chevron-left"></i> </button></a>
+    <a href="/sregistry-cli/client-google-storage"><button class="next-button btn btn-primary"><i class="fa fa-chevron-right"></i> </button></a>
+</div><br>

--- a/sregistry/main/base/http.py
+++ b/sregistry/main/base/http.py
@@ -235,7 +235,7 @@ def stream_response(self, response, stream_to=None):
 
 def call(self, url, func, data=None, headers=None, 
                           return_json=True, stream=False, 
-                          retry=True):
+                          retry=True, default_headers=True):
 
     '''call will issue the call, and issue a refresh token
     given a 401 response, and if the client has a _update_token function
@@ -247,13 +247,18 @@ def call(self, url, func, data=None, headers=None,
     headers: if not None, update the client self.headers with dictionary
     data: additional data to add to the request
     return_json: return json if successful
+    default_headers: use the client's self.headers (default True)
+
     '''
  
     if data is not None:
         if not isinstance(data,dict):
             data = json.dumps(data)
 
-    heads = self.headers.copy()
+    heads = dict()
+    if default_headers is True:
+        heads = self.headers.copy()
+    
     if headers is not None:
         if isinstance(headers,dict):
             heads.update(headers)

--- a/sregistry/main/base/http.py
+++ b/sregistry/main/base/http.py
@@ -33,17 +33,18 @@ import re
 import os
 
 
-def delete(self,url,headers=None,return_json=True):
+def delete(self,url,headers=None,return_json=True, default_headers=True):
     '''delete request, use with caution
     '''
     bot.debug('DELETE %s' %url)
     return self._call(url,
                       headers=headers,
                       func=requests.delete,
-                      return_json=return_json)
+                      return_json=return_json,
+                      default_headers=default_headers)
 
 
-def put(self,url,headers=None,data=None,return_json=True):
+def put(self,url,headers=None,data=None,return_json=True,default_headers=True):
     '''put request
     '''
     bot.debug("PUT %s" %url)
@@ -51,22 +52,35 @@ def put(self,url,headers=None,data=None,return_json=True):
                       headers=headers,
                       func=requests.put,
                       data=data,
-                      return_json=return_json)
+                      return_json=return_json,
+                      default_headers=default_headers)
 
 
+def post(self,url,
+              headers=None,
+              data=None,
+              return_json=True,
+              default_headers=True):
 
-def post(self,url,headers=None,data=None,return_json=True):
     '''post will use requests to get a particular url
     '''
+
     bot.debug("POST %s" %url)
     return self._call(url,
                       headers=headers,
                       func=requests.post,
                       data=data,
-                      return_json=return_json)
+                      return_json=return_json,
+                      default_headers=default_headers)
 
 
-def get(self,url,headers=None,token=None,data=None,return_json=True):
+def get(self,url,
+             headers=None,
+             token=None,
+             data=None,
+             return_json=True,
+             default_headers=True):
+
     '''get will use requests to get a particular url
     '''
     bot.debug("GET %s" %url)
@@ -74,8 +88,8 @@ def get(self,url,headers=None,token=None,data=None,return_json=True):
                       headers=headers,
                       func=requests.get,
                       data=data,
-                      return_json=return_json)
-
+                      return_json=return_json,
+                      default_headers=default_headers)
 
 def paginate_get(self, url, headers=None, return_json=True, start_page=None):
     '''paginate_call is a wrapper for get to paginate results
@@ -144,7 +158,11 @@ def download(self, url, file_name, headers=None, show_progress=True):
     return file_name
 
 
-def stream(self, url, headers=None, stream_to=None, retry=True):
+def stream(self, url, 
+                 headers=None, 
+                 stream_to=None,
+                 retry=True, 
+                 default_headers=True):
     '''
 
        stream is a get that will stream to file_name. This stream is intended
@@ -252,7 +270,7 @@ def call(self, url, func, data=None, headers=None,
     '''
  
     if data is not None:
-        if not isinstance(data,dict):
+        if not isinstance(data, dict):
             data = json.dumps(data)
 
     heads = dict()
@@ -260,7 +278,7 @@ def call(self, url, func, data=None, headers=None,
         heads = self.headers.copy()
     
     if headers is not None:
-        if isinstance(headers,dict):
+        if isinstance(headers, dict):
             heads.update(headers)
 
     response = func(url=url,
@@ -270,7 +288,7 @@ def call(self, url, func, data=None, headers=None,
                     stream=stream)
 
     # Errored response, try again with refresh
-    if response.status_code in [500,502]:
+    if response.status_code in [500, 502]:
         bot.error("Beep boop! %s: %s" %(response.reason,
                                         response.status_code))
         sys.exit(1)

--- a/sregistry/main/docker/api.py
+++ b/sregistry/main/docker/api.py
@@ -65,6 +65,7 @@ def update_token(self, response):
 
     token_url = realm + '?service=' + service + '&expires_in=900&scope=' + scope
 
+    # Default headers must be False so that client's current headers not used
     response = self._get(token_url)
 
     try:
@@ -160,15 +161,16 @@ def get_manifest(self, repo_name, digest=None, schema_version="v1"):
     '''
 
     url = self._get_manifest_selfLink(repo_name, digest)
-
+    print(url)
     bot.verbose("Obtaining manifest: %s" % url)
 
-    headers = None
-    if schema_version == "v1":
-        headers = {'Accept':'application/json'}
+    #headers = self.headers.copy()
+    #if schema_version == "v1":
+    #    headers.update({'Accept':'application/json'})
 
     # Manifest should always have link to itself
-    manifest = self._get(url, headers=headers)
+    manifest = self._get(url)#, headers=headers)
+    print(manifest)
     manifest['selfLink'] = url
     return manifest
  

--- a/sregistry/main/docker/api.py
+++ b/sregistry/main/docker/api.py
@@ -161,7 +161,6 @@ def get_manifest(self, repo_name, digest=None, schema_version="v1"):
     '''
 
     url = self._get_manifest_selfLink(repo_name, digest)
-    print(url)
     bot.verbose("Obtaining manifest: %s" % url)
 
     #headers = self.headers.copy()
@@ -170,7 +169,6 @@ def get_manifest(self, repo_name, digest=None, schema_version="v1"):
 
     # Manifest should always have link to itself
     manifest = self._get(url)#, headers=headers)
-    print(manifest)
     manifest['selfLink'] = url
     return manifest
  

--- a/sregistry/main/docker/pull.py
+++ b/sregistry/main/docker/pull.py
@@ -74,7 +74,6 @@ def pull(self, images,
         base = self._update_base(image)
         q = parse_image_name(remove_uri(image), base=base)
 
-        print(q)
         digest = q['version'] or q['tag']
 
         # Use Singularity to build the image, based on user preference

--- a/sregistry/main/docker/pull.py
+++ b/sregistry/main/docker/pull.py
@@ -28,7 +28,13 @@ import os
 import sys
 
 
-def pull(self, images, file_name=None, save=True, force=False, **kwargs):
+def pull(self, images, 
+               file_name=None, 
+               save=True, 
+               force=False, 
+               base=None, 
+               **kwargs):
+
     '''pull an image from a docker hub. This is a (less than ideal) workaround
        that actually does the following:
 
@@ -47,10 +53,12 @@ def pull(self, images, file_name=None, save=True, force=False, **kwargs):
                optionally be None if the user wants a default.
     save: if True, you should save the container to the database
           using self.add()
+    base: the registry base, in case the client doesn't want to set in env.
     
     Returns
     =======
     finished: a single container path, or list of paths
+
     '''
 
     if not isinstance(images,list):
@@ -62,8 +70,11 @@ def pull(self, images, file_name=None, save=True, force=False, **kwargs):
     finished = []
     for image in images:
 
-        q = parse_image_name(remove_uri(image))
+        # 0. Update the base in case we aren't working with default
+        base = self._update_base(image)
+        q = parse_image_name(remove_uri(image), base=base)
 
+        print(q)
         digest = q['version'] or q['tag']
 
         # Use Singularity to build the image, based on user preference

--- a/sregistry/main/docker/record.py
+++ b/sregistry/main/docker/record.py
@@ -49,7 +49,10 @@ def record(self, images, action='add'):
     # If used internally we want to return a list to the user.
     for image in images:
 
-        q = parse_image_name(remove_uri(image))
+        # 0. Update the base in case we aren't working with default
+        base = self._update_base(image)
+        q = parse_image_name(remove_uri(image), base=base)
+
         digest = q['version'] or q['tag']
 
         # This is the Docker Hub namespace and repository

--- a/sregistry/utils/names.py
+++ b/sregistry/utils/names.py
@@ -40,7 +40,7 @@ def get_image_hash(image_path):
 def parse_image_name(image_name, tag=None, version=None, 
                                  defaults=True, ext="simg",
                                  default_collection="library",
-                                 default_tag="latest"):
+                                 default_tag="latest", base=None):
 
     '''return a collection and repo name and tag
     for an image file.
@@ -53,7 +53,13 @@ def parse_image_name(image_name, tag=None, version=None,
          over-rides parsed image tag
     defaults: use defaults "latest" for tag and "library"
               for collection. 
+    base: if defined, remove from image_name, appropriate if the
+          user gave a registry url base that isn't part of namespace.
+
     '''
+    if base is not None:
+        image_name = image_name.replace(base,'').strip('/')
+
     result = dict()
     image_name = re.sub('[.](img|simg)','',image_name).lower()
     image_name = re.split('/', image_name, 1)

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -19,7 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.0.67"
+__version__ = "0.0.68"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'


### PR DESCRIPTION
This PR will add support for containers hosted at gcr.io, meaning that we need to take into account an additional "special" authentication header. 

Please see the README.md here for example / instructions, we can merge if it fits the bill!

https://github.com/singularityhub/sregistry-cli/blob/852fb94f4685570740ed88c34c6f4ee7ac83093a/docs/clients/gcr.md

The one remaining issue with images that only have version 2 manifests is that I'm not sure where to get metadata like environment, runscript (cmd/entrypoint) but minimally this will get layers.