### PR TITLE
Fixing header confusion for docker and nvidia cloud manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.0.x)
+ - fixing [bug with environment](https://github.com/singularityhub/sregistry-cli/issues/79) variable export (0.0.69)
  - support for gcr.io, and future "special" token names (0.0.68)
  - adding move (mv) command so client can update database with new path (0.0.67)
  - adding rename command, which renames image in storage (and w/o path assumes name there)

--- a/docs/clients/docker.md
+++ b/docs/clients/docker.md
@@ -67,8 +67,6 @@ The following variables are *shared* between different `sregistry` clients that 
 
 | Variable                    |        Default |          Description |
 |-----------------------------|----------------|----------------------|
-|SREGISTRY_DOCKER_OS       | linux          | The choice of operating system to use from the schema version 2 image manifest |
-|SREGISTRY_DOCKER_ARCHITECTURE| amd64       | the system architecture to use from the schema verison 2 image manifest
 |SREGISTRY_DOCKER_CMD |     not set         | If found as yes/t/true/y or some derivation, use "CMD" instead of "EntryPoint" for container runscript|
 
 
@@ -129,7 +127,7 @@ In [1]: client.speak()
 ## Pull
 The most likely action you want to do with a Docker Hub endpoint is to pull. Pull in this context is different than a pull from Singularity Registry, because we aren't pulling an entire, pre-built image - we are assembling layers at pull time and building an image with them. Specifically we:
 
- 1. **obtain image manifests from Docker Hub** based on an image unique resource identifier (uri) e.g., `ubuntu:latest`. Currently, the image manifests we look for are schemaVersion 1 and 2. Version 1 has important metadata relevant to environment, labels, and the EntryPoint and Cmd (what Singularity will use as the runscript). Version 2 has sizes for layers, and in some cases returns a list of manifests that the user (you!) can choose based on selecting an operating system and system architecture. If you do a simple record (and not pull) it's these manifests that will be obtained and stored in your database.
+ 1. **obtain image manifests from Docker Hub** based on an image unique resource identifier (uri) e.g., `ubuntu:latest`. Currently, the image manifests we look for are schemaVersion 1 and 2, and the image config.
  2. **download layers into a sandbox** and build a squashfs image from the sandbox (per usual with Singularity, build is recommended to do using sudo). The client will detect if you are running the command as sudo (user id 0) and adjust the command to singularity appropriately.
  3. **add the image** to your local storage and sregistry manager so you can find it later.
 

--- a/docs/clients/nvidia.md
+++ b/docs/clients/nvidia.md
@@ -13,7 +13,7 @@ These sections will detail use of the Nvidia Container Cloud client for `sregist
 ## Why would I want to use this?
 Singularity proper will be the best solution if you want to pull and otherwise interact with Docker images. However, the Nvidia Container Cloud uses a slightly different authentication protocol (use of `$oauthtoken` as a username, and password as an API token, and so this client helps to support those customizations.
 
-As with [Docker Hub](/sregistry-cli/client-docker) The images are built from layers, and the layers that you obtain depend on the uri that you ask for, along with the host architecture and operating system. See the [environment](#environment). setting for more details.
+As with [Docker Hub](/sregistry-cli/client-docker) The images are built from layers, and the layers that you obtain depend on the uri that you ask for. See the [environment](#environment). setting for more details.
 
 ## Getting Started
 The Nvidia Container Registry module does not require any extra dependencies other than having Singularity on the host.
@@ -47,8 +47,6 @@ The following variables are *shared* between different `sregistry` clients that 
 
 | Variable                    |        Default |          Description |
 |-----------------------------|----------------|----------------------|
-|SREGISTRY_DOCKER_OS       | linux          | The choice of operating system to use from the schema version 2 image manifest |
-|SREGISTRY_DOCKER_ARCHITECTURE| amd64       | the system architecture to use from the schema verison 2 image manifest
 |SREGISTRY_DOCKER_CMD |     not set         | If found as yes/t/true/y or some derivation, use "CMD" instead of "EntryPoint" for container runscript|
 
 

--- a/sregistry/main/docker/__init__.py
+++ b/sregistry/main/docker/__init__.py
@@ -65,17 +65,14 @@ class Client(ApiConnection):
 
     def _reset_headers(self):
         '''reset headers is called from update_headers, and will update the
-           headers based on what is found with the client secrets
-        '''
+           headers based on what is found with the client secrets.
 
-        # specify wanting version 2 schema
-        # meaning the correct order of digests
-        # returned (base to child)
-        accept = 'application/vnd.docker.distribution.manifest.v2+json,'
-        accept += 'application/vnd.docker.distribution.manifest.list.v2+json,'
-        accept += 'application/json'
+           Note: that Docker expects different headers depending on the 
+                 manifest desired. See:
+                 https://docs.docker.com/registry/spec/manifest-v2-2/
 
-        self.headers = {"Accept": accept,
+        '''        
+        self.headers = {"Accept": 'application/json',
                         'Content-Type': 'application/json; charset=utf-8'}
 
     def _update_base(self, image):
@@ -142,8 +139,12 @@ class Client(ApiConnection):
 
         # If the user has defined secrets, use them
         credentials = self._get_setting('SREGISTRY_DOCKERHUB_SECRETS')
-        username = self._get_setting('SREGISTRY_DOCKERHUB_USERNAME')
-        password = self._get_setting('SREGISTRY_DOCKERHUB_PASSWORD')
+
+        # First try for SINGULARITY exported, then try sregistry
+        username = self._get_setting('SINGULARITY_DOCKER_USERNAME')
+        password = self._get_setting('SINGULARITY_DOCKER_PASSWORD')
+        username = self._get_setting('SREGISTRY_DOCKERHUB_USERNAME', username)
+        password = self._get_setting('SREGISTRY_DOCKERHUB_PASSWORD', password)
 
         # Option 1: the user exports username and password
         if username is not None and password is not None:


### PR DESCRIPTION
This PR will fix #79 and the reader should see the discussion there for the working example. Here is a brief summary:

 - there are now different manifests for the image config, version 1, and version 2
 - we don't "hard code" any of the headers into the base call, we add them (as variable) as needed
 - the code is GREATLY simplified and importantly it works!

With credentials exported, the user should be able to:

```
sregistry pull nvidia://pytorch:17.12
singularity shell --nv $(sregistry get nvidia/pytorch:17.12)
WARNING: Could not find the Nvidia SMI binary to bind into container

Singularity: Invoking an interactive shell within container...

$ echo $PATH
/opt/conda/envs/pytorch-py3.6/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```
@slefrancois  would you like to test? If it looks good we can merge, and then I will update the pypi package too.