### PR TITLE
quick fix to get environment tar for non debian architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.0.x)
+ - adding fix to allow for os that don't have `dpkg-architecture` (0.0.70)
  - fixing [bug with environment](https://github.com/singularityhub/sregistry-cli/issues/79) variable export (0.0.69)
  - support for gcr.io, and future "special" token names (0.0.68)
  - adding move (mv) command so client can update database with new path (0.0.67)

--- a/sregistry/main/docker/api.py
+++ b/sregistry/main/docker/api.py
@@ -429,13 +429,16 @@ def get_environment_tar(self):
         return envtar
 
     # Second attempt, debian distribution will identify folder
-    res = which('dpkg-architecture')['message']
-    if res is not None:
-        cmd = ['dpkg-architecture', '-qDEB_HOST_MULTIARCH']
-        triplet = run_command(cmd)['message'].strip('\n')
-        envtar = '/usr/lib/%s/singularity/bootstrap-scripts/environment.tar' %triplet
-        if os.path.exists(envtar):
-            return envtar
+    try:
+        res = which('dpkg-architecture')['message']
+        if res is not None:
+            cmd = ['dpkg-architecture', '-qDEB_HOST_MULTIARCH']
+            triplet = run_command(cmd)['message'].strip('\n')
+            envtar = '/usr/lib/%s/singularity/bootstrap-scripts/environment.tar' %triplet
+            if os.path.exists(envtar):
+                return envtar
+    except:
+        pass
 
     # Final, return environment.tar provided in package
     return "%s/environment.tar" %os.path.abspath(os.path.dirname(__file__))

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -19,7 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.0.69"
+__version__ = "0.0.70"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'


### PR DESCRIPTION
This is a quick fix that will resolve an error on non debian systems that don't have dpkg-architecture. We can use the default environment files provided by the library.