### PR TITLE
houston, we have config from a schema version 2.0 manifest blob!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.0.x)
+ - fixed issue with missing registry version 2.0 manifest! (0.0.72)
  - print of "Unauthorized(403)" when client asks to pull private collection (0.0.71)
  - adding fix to allow for os that don't have `dpkg-architecture` (0.0.70)
  - adding help and support links to docs (doesn't alter functionality)

--- a/sregistry/main/docker/__init__.py
+++ b/sregistry/main/docker/__init__.py
@@ -29,8 +29,8 @@ import os
 # here you should import the functions from the files in this
 # folder that you add to your client (at the bottom)
 from .api import ( create_metadata_tar, download_layers, get_manifest_selfLink,
-                   get_config, get_digests, get_layer, get_manifest,
-                   get_manifests, get_download_cache, get_size,
+                   get_config, get_digests, get_layer, get_layerLink, 
+                   get_manifest, get_manifests, get_download_cache, get_size,
                    extract_env, extract_labels, extract_runscript,
                    update_token, get_environment_tar )
 from .pull import pull
@@ -193,6 +193,7 @@ Client._get_config = get_config
 Client._get_digests = get_digests
 Client._get_download_cache = get_download_cache
 Client._get_layer = get_layer
+Client._get_layerLink = get_layerLink
 Client._get_manifest = get_manifest
 Client._get_manifests = get_manifests
 Client._get_size = get_size

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -19,7 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.0.71"
+__version__ = "0.0.72"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'


### PR DESCRIPTION
This PR will fix the bug that some version 2.0 manifests don't come with a config endpoint or a version 1.0. Specifically, we look for a "config" index in the version 2.0, under which is a blob that is actually the manifest. This should fix sregistry to work with gcr.io images. 