### PR TITLE
doing try/except for metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.0.x)
+ - making "inspect" optional on pull so that we don't error out running in Docker (0.0.73)
  - fixed issue with missing registry version 2.0 manifest! (0.0.72)
  - print of "Unauthorized(403)" when client asks to pull private collection (0.0.71)
  - adding fix to allow for os that don't have `dpkg-architecture` (0.0.70)

--- a/sregistry/main/base/inspect.py
+++ b/sregistry/main/base/inspect.py
@@ -71,7 +71,7 @@ def get_metadata(self, image_file, names={}):
             cli = Singularity()
             updates = cli.inspect(image_path=image_file, quiet=True)
         except:
-            bot.warning('Inspect command not supported, no included.')
+            bot.warning('Inspect command not supported, metadata not included.')
             updates = None
 
         # Try loading the metadata

--- a/sregistry/main/base/inspect.py
+++ b/sregistry/main/base/inspect.py
@@ -27,6 +27,7 @@ from sregistry.utils import (
     which 
 )
 
+from sregistry.logger import bot
 from sregistry.auth import ( read_client_secrets, update_client_secrets )
 import os
 import json
@@ -64,8 +65,14 @@ def get_metadata(self, image_file, names={}):
     # Inspect the image, or return names only
     if os.path.exists(singularity) and image_file is not None:
         from sregistry.client import Singularity
-        cli = Singularity()
-        updates = cli.inspect(image_path=image_file, quiet=True)
+
+        # We try and inspect, but not required (wont work within Docker)
+        try:
+            cli = Singularity()
+            updates = cli.inspect(image_path=image_file, quiet=True)
+        except:
+            bot.warning('Inspect command not supported, no included.')
+            updates = None
 
         # Try loading the metadata
         if updates is not None:

--- a/sregistry/main/registry/pull.py
+++ b/sregistry/main/registry/pull.py
@@ -76,9 +76,6 @@ def pull(self, images, file_name=None, save=True, **kwargs):
                 self._update_headers(headers)
                 manifest = self._get(url)
 
-                # Still denied
-                if manifest.status_code == 403:
-                    manifest = 403
 
         if isinstance(manifest, int):
             if manifest == 400:

--- a/sregistry/main/registry/pull.py
+++ b/sregistry/main/registry/pull.py
@@ -76,6 +76,10 @@ def pull(self, images, file_name=None, save=True, **kwargs):
                 self._update_headers(headers)
                 manifest = self._get(url)
 
+                # Still denied
+                if isinstance(manifest, Response):
+                    if manifest.status_code == 403:
+                        manifest = 403
 
         if isinstance(manifest, int):
             if manifest == 400:
@@ -119,27 +123,3 @@ def pull(self, images, file_name=None, save=True, **kwargs):
         if len(finished) == 1:
             finished = finished[0]
         return finished
-
-
-    upload_to = os.path.basename(names['storage'])
-
-    encoder = MultipartEncoder(fields={'collection': names['collection'],
-                                       'name':names['image'],
-                                       'metadata':metadata,
-                                       'tag': names['tag'],
-                                       'datafile': (upload_to, open(upload_from, 'rb'), 'text/plain')})
-
-    progress_callback = create_callback(encoder)
-    monitor = MultipartEncoderMonitor(encoder, progress_callback)
-    headers = {'Content-Type': monitor.content_type,
-               'Authorization': SREGISTRY_EVENT }
-
-    try:
-        r = requests.post(url, data=monitor, headers=headers)
-        message = self._read_response(r)
-
-        print('\n[Return status {0} {1}]'.format(r.status_code, message))
-
-    except KeyboardInterrupt:
-        print('\nUpload cancelled.')
-

--- a/sregistry/main/registry/push.py
+++ b/sregistry/main/registry/push.py
@@ -57,6 +57,7 @@ def push(self, path, name, tag=None):
     metadata = self.get_metadata(path, names=names)
 
     # Try to add the size
+
     try:
         image_size = os.path.getsize(path) >> 20
         if metadata['data']['attributes']['labels'] is None:
@@ -69,13 +70,21 @@ def push(self, path, name, tag=None):
         pass
 
 
-    if "deffile" in metadata['data']['attributes']:
-        if metadata['data']['attributes']['deffile'] is not None:
-            fromimage = parse_header(metadata['data']['attributes']['deffile'],
-                                     header="from",
-                                     remove_header=True) 
-            metadata['data']['attributes']['labels']['SREGISTRY_FROM'] = fromimage
-            bot.debug("%s was built from a definition file." % image)
+    # Try to add the from
+
+    if "data" in metadata:
+        if 'attributes' in metadata['data']:
+            if metadata['data']['attributes'].get('deffile') is not None:
+                fromimage = parse_header(metadata['data']['attributes']['deffile'],
+                                         header="from",
+                                         remove_header=True) 
+
+                # Add label for from
+                if 'labels' not in metadata['data']['attributes']:
+                    metadata['data']['attributes']['labels'] = dict()
+
+                metadata['data']['attributes']['labels']['SREGISTRY_FROM'] = fromimage
+                bot.debug("%s was built from a definition file." % image)
 
 
     # Prepare push request with multipart encoder

--- a/sregistry/main/registry/push.py
+++ b/sregistry/main/registry/push.py
@@ -56,36 +56,15 @@ def push(self, path, name, tag=None):
     names = parse_image_name(remove_uri(name), tag=tag)
     metadata = self.get_metadata(path, names=names)
 
+    # Add expected attributes
+    if "data" not in metadata:
+        metadata['data'] = {'attributes': {'labels': dict() }}
+
     # Try to add the size
-
-    try:
-        image_size = os.path.getsize(path) >> 20
-        if metadata['data']['attributes']['labels'] is None:
-            metadata['data']['attributes']['labels'] = {'SREGISTRY_SIZE_MB': image_size }
-        else:
-            metadata['data']['attributes']['labels']['SREGISTRY_SIZE_MB'] = image_size
-
-    except:
-        bot.warning("Cannot load metadata to add calculated size.")
-        pass
-
-
-    # Try to add the from
-
-    if "data" in metadata:
-        if 'attributes' in metadata['data']:
-            if metadata['data']['attributes'].get('deffile') is not None:
-                fromimage = parse_header(metadata['data']['attributes']['deffile'],
-                                         header="from",
-                                         remove_header=True) 
-
-                # Add label for from
-                if 'labels' not in metadata['data']['attributes']:
-                    metadata['data']['attributes']['labels'] = dict()
-
-                metadata['data']['attributes']['labels']['SREGISTRY_FROM'] = fromimage
-                bot.debug("%s was built from a definition file." % image)
-
+    image_size = os.path.getsize(path) >> 20
+    fromimage = os.path.basename(path)
+    metadata['data']['attributes']['labels']['SREGISTRY_SIZE_MB'] = image_size
+    metadata['data']['attributes']['labels']['SREGISTRY_FROM'] = fromimage
 
     # Prepare push request with multipart encoder
     url = '%s/push/' % self.base

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -19,7 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.0.72"
+__version__ = "0.0.73"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'


### PR DESCRIPTION
this will make inspect optional on pull, (or generally when used) in the case that the client is being run inside docker (where singularity doesn't seem to consistently work!)