### PR TITLE
fixing push bug with NoneType object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.0.x)
+ - fixing bug that registry does not have label for size in metadata (0.0.79)
  - consolidating shared pull functionality between nvidia and docker (0.0.78)
  - updating pull to handle whiteout files, adding THIRD-PARTY-NOTICES (0.0.77)
  - version bump to add google-compute builder startup files (0.0.76)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-spython==0.0.22
+spython==0.0.23
 requests

--- a/sregistry/main/base/inspect.py
+++ b/sregistry/main/base/inspect.py
@@ -52,7 +52,7 @@ def get_metadata(self, image_file, names={}):
     if image_file is not None:
         if not os.path.exists(image_file):
             bot.error('Cannot find %s.' %image_file)
-            return names
+            return names or metadata
 
     # The user provided a file, but no names
     if not names:

--- a/sregistry/main/base/inspect.py
+++ b/sregistry/main/base/inspect.py
@@ -46,7 +46,6 @@ def get_metadata(self, image_file, names={}):
               variables for the image, likely from utils.parse_image_name
 
     '''
-
     metadata = dict()
 
     # We can't return anything without image_file or names

--- a/sregistry/main/registry/push.py
+++ b/sregistry/main/registry/push.py
@@ -55,7 +55,7 @@ def push(self, path, name, tag=None):
     # Extract the metadata
     names = parse_image_name(remove_uri(name), tag=tag)
     metadata = self.get_metadata(path, names=names) or {}
-     
+
     # Add expected attributes
     if "data" not in metadata:
         metadata['data'] = {'attributes': {'labels': dict() }}

--- a/sregistry/main/registry/push.py
+++ b/sregistry/main/registry/push.py
@@ -58,7 +58,11 @@ def push(self, path, name, tag=None):
 
     # Add expected attributes
     if "data" not in metadata:
-        metadata['data'] = {'attributes': {'labels': dict() }}
+        metadata['data'] = {'attributes': {}}
+    if "labels"not in metadata['data']['attributes']:
+        metadata['data']['attributes'] = {'labels': {} }
+    if metadata['data']['attributes']['labels'] == None:
+        metadata['data']['attributes']['labels'] = {}
 
     # Try to add the size
     image_size = os.path.getsize(path) >> 20

--- a/sregistry/main/registry/push.py
+++ b/sregistry/main/registry/push.py
@@ -60,7 +60,7 @@ def push(self, path, name, tag=None):
     if "data" not in metadata:
         metadata['data'] = {'attributes': {}}
     if "labels" not in metadata['data']['attributes']:
-        metadata['data']['attributes'] = {'labels': {} }
+        metadata['data']['attributes']['labels'] = {}
     if metadata['data']['attributes']['labels'] == None:
         metadata['data']['attributes']['labels'] = {}
 

--- a/sregistry/main/registry/push.py
+++ b/sregistry/main/registry/push.py
@@ -59,7 +59,7 @@ def push(self, path, name, tag=None):
     # Add expected attributes
     if "data" not in metadata:
         metadata['data'] = {'attributes': {}}
-    if "labels"not in metadata['data']['attributes']:
+    if "labels" not in metadata['data']['attributes']:
         metadata['data']['attributes'] = {'labels': {} }
     if metadata['data']['attributes']['labels'] == None:
         metadata['data']['attributes']['labels'] = {}

--- a/sregistry/main/registry/push.py
+++ b/sregistry/main/registry/push.py
@@ -54,8 +54,8 @@ def push(self, path, name, tag=None):
 
     # Extract the metadata
     names = parse_image_name(remove_uri(name), tag=tag)
-    metadata = self.get_metadata(path, names=names)
-
+    metadata = self.get_metadata(path, names=names) or {}
+     
     # Add expected attributes
     if "data" not in metadata:
         metadata['data'] = {'attributes': {'labels': dict() }}

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -19,7 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.0.78"
+__version__ = "0.0.79"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'


### PR DESCRIPTION
This will fix the error of not having the metadata key, in the case that the client cannot inspect.