### PR TITLE
updating globus client to have function to get a single endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.0.x)
+ - adding get_endpoint function to Globus (0.0.81)
  - adding globus integration (0.0.80)
  - fixing bug that registry does not have label for size in metadata (0.0.79)
  - consolidating shared pull functionality between nvidia and docker (0.0.78)

--- a/docs/clients/globus.md
+++ b/docs/clients/globus.md
@@ -40,7 +40,7 @@ you can also prepend it to any sregistry command:
 $ SREGISTRY_CLIENT=globus sregistry shell
 ```
 
-### Your Globus  Personal Endpoint
+### Your Globus Personal Endpoint
 A globus personal endpoint is referring to a computer (such as yours!) that can be
 connected to via Globus, meaning that a small set of directories that you've designated
 can share files with others that use Globus. This also means that you can transfer files
@@ -428,6 +428,70 @@ get a successful transfer message. You can also use this as an opportunity to re
 
 ```
 $ sregistry add --name sherlock/better-pancakes /home/vanessa/.singularity/shub/sherlock/pancakes\:latest.simg
+```
+
+# Python Shell
+The above commands are also available, and with more robust usage from within
+a Python shell, for developers and users alike! You can open a shell with
+the client loaded:
+
+```
+sregistry shell globus://
+[client|globus] [database|sqlite:////home/vanessa/.singularity/sregistry.db]
+Python 3.5.2 |Anaconda 4.2.0 (64-bit)| (default, Jul  2 2016, 17:53:06) 
+Type "copyright", "credits" or "license" for more information.
+
+IPython 5.1.0 -- An enhanced Interactive Python.
+?         -> Introduction and overview of IPython's features.
+%quickref -> Quick reference.
+help      -> Python's own help system.
+object?   -> Details about 'object', use 'object??' for extra details.
+
+In [1]:
+```
+
+The `client` variable is already loaded. You can see the functions available 
+if you do a TAB complete with `_get`:
+
+```
+In [1]: client._get
+                   client._get                    client._get_endpoint_path      client._get_setting             
+                   client._get_and_update_setting client._get_endpoints          client._get_settings            
+                   client._get_endpoint           client._get_headers            client._get_storage_name 
+```
+
+For example, you can list endpoints as you did before, with or without a search
+term:
+
+```
+$ client._list_endpoints()
+...
+  '[my-endpoints]',
+  '29890592-374e-11e8-b96a-0ac6873fc732'],
+ ['aa82607a-3466-11e8-b92a-0ac6873fc732',
+  '[my-endpoints]',
+  'aa82607a-3466-11e8-b92a-0ac6873fc732'],
+ ['9ec1db6a-5052-11e7-bdb7-22000b9a448b',
+  '[shared-with-me]',
+  '9ec1db6a-5052-11e7-bdb7-22000b9a448b']]
+```
+
+And then get a single endpoint based on the endpoint id.
+
+```
+$ client._get_endpoint('9ec1db6a-5052-11e7-bdb7-22000b9a448b')
+...
+ 'sharing_target_root_path': None,
+ 'storage_type': None,
+ 'subscription_id': None,
+ 'username': 'u_b6cdsmgivbe2be4wnfkorwj2sm'}
+```
+
+If you are authenticated (some require two factor authentication) then you can
+list the contents of a single endpoint:
+
+```
+$ client._list_endpoint('9ec1db6a-5052-11e7-bdb7-22000b9a448b')
 ```
 
 This is the first implementation of Globus, and if you have feedback please <a href="https://www.github.com/singularityhub/sregistry-cli/issues" target="_blank">let us know!</a>

--- a/sregistry/defaults.py
+++ b/sregistry/defaults.py
@@ -20,9 +20,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 '''
 
 from sregistry.logger import bot
+from sregistry.utils import get_userhome
 import tempfile
 import os
-import pwd
 import sys
 
 ################################################################################
@@ -67,7 +67,7 @@ def getenv(variable_key, default=None, required=False, silent=True):
 # Global Settings
 #########################
 
-USERHOME = pwd.getpwuid(os.getuid())[5]
+USERHOME = get_userhome()
 DISABLE_CACHE = convert2boolean(getenv("SINGULARITY_DISABLE_CACHE", False))
 DISABLE_DATABASE = convert2boolean(getenv("SREGISTRY_DISABLE", False))
 SREGISTRY_CLIENT = getenv("SREGISTRY_CLIENT", "hub")
@@ -128,8 +128,7 @@ DISABLE_CREDENTIAL_CACHE = convert2boolean(DISABLE_CREDENTIAL_CACHE)
 CREDENTIAL_CACHE = None
 
 # Download Cache for Singularity layers (not complete images)
-userhome = pwd.getpwuid(os.getuid())[5]
-_cache = os.path.join(userhome, ".singularity")
+_cache = os.path.join(USERHOME, ".singularity")
 SINGULARITY_CACHE = getenv("SINGULARITY_CACHEDIR", default=_cache)
 
 _secrets = os.path.join(USERHOME, ".sregistry")

--- a/sregistry/main/globus/__init__.py
+++ b/sregistry/main/globus/__init__.py
@@ -31,6 +31,7 @@ import os
 from .utils import (
     create_endpoint_cache,
     create_endpoint_folder,
+    get_endpoint,
     get_endpoints,
     get_endpoint_path,
     init_transfer_client,
@@ -81,7 +82,7 @@ class Client(ApiConnection):
        
         self.auth = self._get_and_update_setting('GLOBUS_AUTH_RESPONSE')
         self.transfer = self._get_and_update_setting('GLOBUS_TRANSFER_RESPONSE')
-
+        
 
     # Runtime Calls
 
@@ -129,7 +130,8 @@ Client._init_transfer_client = init_transfer_client
 # Endpoints
 Client._create_endpoint_cache = create_endpoint_cache
 Client._create_endpoint_folder = create_endpoint_folder
-Client._get_endpoints = get_endpoints        
+Client._get_endpoint = get_endpoint
+Client._get_endpoints = get_endpoints
 Client._parse_endpoint_name = parse_endpoint_name
 Client._get_endpoint_path = get_endpoint_path
 

--- a/sregistry/main/globus/utils.py
+++ b/sregistry/main/globus/utils.py
@@ -134,6 +134,26 @@ def init_transfer_client(self):
     self.transfer_client = globus_sdk.TransferClient(authorizer=authorizer)
 
 
+def get_endpoint(self, endpoint_id):
+    '''use a transfer client to get a specific endpoint based on an endpoint id.
+       
+       Parameters
+       ==========
+       endpoint_id: the endpoint_id to retrieve
+
+    ''' 
+    endpoint = None
+    
+    if not hasattr(self, 'transfer_client'):
+        self._init_transfer_client()
+
+    try:
+        endpoint = self.transfer_client.get_endpoint(endpoint_id).data
+    except TransferAPIError:
+        bot.info('%s does not exist.' %endpoint_id)
+    
+    return endpoint
+
 
 def get_endpoints(self, query=None):
     '''use a transfer client to get endpoints. If a search term is included,

--- a/sregistry/utils/__init__.py
+++ b/sregistry/utils/__init__.py
@@ -23,6 +23,7 @@ from .fileio import (
     copyfile,
     create_tar,
     extract_tar,
+    get_userhome,
     mkdir_p,
     print_json,
     read_file,

--- a/sregistry/utils/cache.py
+++ b/sregistry/utils/cache.py
@@ -20,7 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 '''
 
 from sregistry.logger import bot
-from .fileio import mkdir_p
+from .fileio import mkdir_p, get_userhome
 import tempfile
 import os
 import pwd

--- a/sregistry/utils/fileio.py
+++ b/sregistry/utils/fileio.py
@@ -23,6 +23,7 @@ import datetime
 import hashlib
 import errno
 import os
+import pwd
 import re
 import shutil
 import tempfile
@@ -53,6 +54,13 @@ def mkdir_p(path):
         else:
             bot.error("Error creating path %s, exiting." % path)
             sys.exit(1)
+
+
+def get_userhome():
+    '''get the user home based on the effective uid
+    '''
+    return pwd.getpwuid(os.getuid())[5]
+
 
 ############################################################################
 ## COMPRESSION #############################################################

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -19,7 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.0.80"
+__version__ = "0.0.81"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'


### PR DESCRIPTION
It's logical to have a function to retrieve a single endpoint based on its id, right now we just can return based on a search term.

```
$ client._get_endpoint('9ec1db6a-5052-11e7-bdb7-22000b9a448b')
...
 'sharing_target_root_path': None,
 'storage_type': None,
 'subscription_id': None,
 'username': 'u_b6cdsmgivbe2be4wnfkorwj2sm'}
```
