### PR TITLE
Upgrade client for sregistry to use nginx upload module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.0.x)
+ - adding chunked upload to chunk uploads to Singularity Registry (0.0.87)
  - updating Dockerfile and Singularity recipt with additional dependencies for 2.5 (0.0.86).
  - removing Globus dependency to avoid install conflict (0.0.85)
  - added client command to add, list, activate, and remove backends (0.0.84)

--- a/sregistry/client/__init__.py
+++ b/sregistry/client/__init__.py
@@ -73,12 +73,13 @@ def get_parser():
                        type=str, default=None)
 
     # List local containers and collections
-    images = subparsers.add_parser("images",
-                                   help="list local images, optionally with query")
+    if hasattr(cli, 'images'):
+        images = subparsers.add_parser("images",
+                                       help="list local images, optionally with query")
 
-    images.add_argument("query", nargs='*', 
-                        help="container search query", 
-                        type=str, default="*")
+        images.add_argument("query", nargs='*', 
+                            help="container search query", 
+                            type=str, default="*")
 
 
     # List local containers and collections
@@ -373,14 +374,13 @@ def main():
 
     # Pass on to the correct parser
     return_code = 0
-    if 1==1:
-    #try:
+    try:
         main(args=args,
              parser=parser,
              subparser=subparsers[args.command])
         sys.exit(return_code)
-    #except UnboundLocalError:
-    #    return_code = 1
+    except UnboundLocalError:
+        return_code = 1
 
     help(return_code)
 

--- a/sregistry/main/registry/push.py
+++ b/sregistry/main/registry/push.py
@@ -27,13 +27,14 @@ from sregistry.utils import (
     parse_header,
     remove_uri
 )
+from requests_toolbelt.streaming_iterator import StreamingIterator
 from requests_toolbelt import (
     MultipartEncoder,
     MultipartEncoderMonitor
 )
 
 import requests
-import json
+import hashlib
 import sys
 import os
 
@@ -54,34 +55,48 @@ def push(self, path, name, tag=None):
 
     # Extract the metadata
     names = parse_image_name(remove_uri(name), tag=tag)
-    metadata = self.get_metadata(path, names=names) or {}
-
-    # Add expected attributes
-    if "data" not in metadata:
-        metadata['data'] = {'attributes': {}}
-    if "labels" not in metadata['data']['attributes']:
-        metadata['data']['attributes']['labels'] = {}
-    if metadata['data']['attributes']['labels'] == None:
-        metadata['data']['attributes']['labels'] = {}
-
-    # Try to add the size
     image_size = os.path.getsize(path) >> 20
-    fromimage = os.path.basename(path)
-    metadata['data']['attributes']['labels']['SREGISTRY_SIZE_MB'] = image_size
-    metadata['data']['attributes']['labels']['SREGISTRY_FROM'] = fromimage
 
-    # Prepare push request with multipart encoder
+# COLLECTION ###################################################################
+    
+    # Prepare push request, this will return a collection ID if permission
     url = '%s/push/' % self.base
-    upload_to = os.path.basename(names['storage'])
-
+    auth_url = '%s/upload/chunked_upload' % self.base
     SREGISTRY_EVENT = self.authorize(request_type="push",
                                      names=names)
 
-    encoder = MultipartEncoder(fields={'collection': names['collection'],
-                                       'name':names['image'],
-                                       'metadata': json.dumps(metadata),
+    # Data fields for collection
+    fields = { 'collection': names['collection'],
+               'name':names['image'],
+               'tag': names['tag']}
+
+    headers = { 'Authorization': SREGISTRY_EVENT }
+    
+    r = requests.post(auth_url, json=fields, headers=headers)
+
+    # Always tell the user what's going on!
+    message = self._read_response(r)
+    print('\n[1. Collection return status {0} {1}]'.format(r.status_code, message))
+
+    # Get the collection id, if created, and continue with upload
+    if r.status_code != 200:
+        sys.exit(1)
+
+
+# UPLOAD #######################################################################
+
+    url = '%s/upload' % self.base.strip('api/')
+    cid = r.json()['cid']
+    upload_to = os.path.basename(names['storage'])
+
+    SREGISTRY_EVENT = self.authorize(request_type="upload",
+                                     names=names)
+
+    encoder = MultipartEncoder(fields={'SREGISTRY_EVENT': SREGISTRY_EVENT,
+                                       'name': names['image'],
+                                       'collection': str(cid),
                                        'tag': names['tag'],
-                                       'datafile': (upload_to, open(path, 'rb'), 'text/plain')})
+                                       'file1': (upload_to, open(path, 'rb'), 'text/plain')})
 
     progress_callback = create_callback(encoder)
     monitor = MultipartEncoderMonitor(encoder, progress_callback)
@@ -90,109 +105,18 @@ def push(self, path, name, tag=None):
 
     try:
         r = requests.post(url, data=monitor, headers=headers)
-        message = self._read_response(r)
-
+        message = r.json()['message']
         print('\n[Return status {0} {1}]'.format(r.status_code, message))
-
     except KeyboardInterrupt:
         print('\nUpload cancelled.')
-
-
-
-
-
-/api/containers/upload-complete/	shub.apps.api.actions.upload.ShubChunkedUploadCompleteView	api_chunked_upload_complete
-/api/containers/upload/	shub.apps.api.actions.upload.ShubChunkedUploadView	api_chunked_upload
-
-
-
-
-
- <script type="text/javascript">
-    var md5 = "",
-        csrf = $("input[name='csrfmiddlewaretoken']")[0].value,
-        form_data = [{"name": "csrfmiddlewaretoken", "value": csrf}];
-    function calculate_md5(file, chunk_size) {
-      var slice = File.prototype.slice || File.prototype.mozSlice || File.prototype.webkitSlice,
-          chunks = chunks = Math.ceil(file.size / chunk_size),
-          current_chunk = 0,
-          spark = new SparkMD5.ArrayBuffer();
-      function onload(e) {
-        spark.append(e.target.result);  // append chunk
-        current_chunk++;
-        if (current_chunk < chunks) {
-          read_next_chunk();
-        } else {
-          md5 = spark.end();
-        }
-      };
-      function read_next_chunk() {
-        var reader = new FileReader();
-        reader.onload = onload;
-        var start = current_chunk * chunk_size,
-            end = Math.min(start + chunk_size, file.size);
-        reader.readAsArrayBuffer(slice.call(file, start, end));
-      };
-      read_next_chunk();
-    }
-    $("#chunked_upload").fileupload({
-      url: "{% url 'api_chunked_upload' %}",
-      dataType: "json",
-      maxChunkSize: 100000, // Chunks of 100 kB
-      formData: form_data,
-      add: function(e, data) { // Called before starting upload
-        $("#messages").empty();
-        // If this is the second file you're uploading we need to remove the
-        // old upload_id and just keep the csrftoken (which is always first).
-        form_data.splice(1);
-        calculate_md5(data.files[0], 100000);  // Again, chunks of 100 kB
-        data.submit();
-      },
-      chunkdone: function (e, data) { // Called after uploading each chunk
-        if (form_data.length < 2) {
-          form_data.push(
-            {"name": "upload_id", "value": data.result.upload_id}
-          );
-        }
-        $("#messages").append($('<p>').text(JSON.stringify(data.result)));
-        var progress = parseInt(data.loaded / data.total * 100.0, 10);
-        $("#progress").text(Array(progress).join("=") + "> " + progress + "%");
-      },
-      done: function (e, data) { // Called when the file has completely uploaded
-        $.ajax({
-          type: "POST",
-          url: "{% url 'api_chunked_upload_complete' %}",
-          data: {
-            csrfmiddlewaretoken: csrf,
-            upload_id: data.result.upload_id,
-            md5: md5
-          },
-          dataType: "json",
-          success: function(data) {
-            $("#messages").append($('<p>').text(JSON.stringify(data)));
-          }
-        });
-      },
-    });
-  </script>
-
-</body>
-</html>
-
-
-
-
-
-
-
+    except Exception as e:
+        print(e)
 
 
 def create_callback(encoder):
-    print(encoder)
     encoder_len = encoder.len / (1024*1024.0)
     bar = ProgressBar(expected_size=encoder_len,
                       filled_char='=')
     def callback(monitor):
-        print(monitor)
         bar.show(monitor.bytes_read / (1024*1024.0))
     return callback

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -19,7 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.0.86"
+__version__ = "0.0.87"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'


### PR DESCRIPTION
This PR will close the following issues related to not being able to upload large containers:
  - #126 
  - #123 

This is the branch that should be used to test uploading to https://github.com/singularityhub/sregistry/pull/134 (the old method will no longer work)

I had originally planned to add chunked upload to Singularity Registry server. I did, and this was a web interface with a progress bar, etc. I was not happy with trying to get the same for an upload from the command line, so I scratched django chunked upload. Instead, I am using nginx upload module to (super speedily) upload files directly to the server from nginx.

In the code to do the push, you will now see two authentication checks. Both send an encrypted payload (with the user's token secret) to the server, and this payload is used to identify the user, check permissions, and finally authenticate the upload request. The first time a collection is returned (and permissions are checked) and we only continue if permissions are adequate. On the server the collection is created if the user has permission to do so and it doesn't exist, and of course a user that doesn't have permission cannot proceed beyond this point.

The second post uses multipart form encoded data to submit directly to the django_upload module, and the callback view then does the equivalent permissions checks, and only continues with processing the upload if everything is (still) ok. I suspect we will want some level of checking permissions on the level of the nginx module, but this can come later (and isn't relevant for this PR anyway).