### PR TITLE
fixing client bug to close #130

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.0.x)
+ - fixing shell client bug (0.0.87)
  - updating Dockerfile and Singularity recipt with additional dependencies for 2.5 (0.0.86).
  - removing Globus dependency to avoid install conflict (0.0.85)
  - added client command to add, list, activate, and remove backends (0.0.84)

--- a/sregistry/client/shell.py
+++ b/sregistry/client/shell.py
@@ -73,7 +73,7 @@ def bpython(args):
     client = get_client(args.endpoint)
     client.announce(args.command)
     from sregistry.database.models import Container, Collection
-    bpython.embed(locals_={'client': cli,
+    bpython.embed(locals_={'client': client,
                            'Container': Container,
                            'Collection': Collection})
 
@@ -83,6 +83,6 @@ def python(args):
     client = get_client(args.endpoint)
     client.announce(args.command)
     from sregistry.database.models import Container, Collection
-    code.interact(local={"client":cli,
+    code.interact(local={"client":client,
                          'Container': Container,
                          'Collection': Collection})

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -19,7 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.0.86"
+__version__ = "0.0.87"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'


### PR DESCRIPTION
This will close #130, a bug in the specification of the name of the client.

@AldoCP would you care to test? You can uninstall sregistry and then install this branch:

```bash
# do this until it says it isn't installed
pip uninstall sregistry

# then install this branch!
git clone -b fix/shell-client-bug https://github.com/singularityhub/sregistry-cli
cd sregistry-cli
python setup.py install
```

When this looks good (and it's such a tiny bug I can't imagine it would still be messed up, but you never know!) I will merge here and release as 0.0.87 on pypi.