### PR TITLE
Fix/lowercase tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.0.x)
+ - image URI tag should not be changed to lowercase (0.0.89)
  - adding chunked upload to chunk uploads to Singularity Registry (0.0.88)
  - fixing shell client bug (0.0.87)
  - updating Dockerfile and Singularity recipt with additional dependencies for 2.5 (0.0.86).

--- a/sregistry/utils/names.py
+++ b/sregistry/utils/names.py
@@ -74,18 +74,18 @@ def parse_image_name(image_name,
         collection = ''
         if defaults is True:
             collection = default_collection
-        image_name = image_name[0].lower()
+        image_name = image_name[0]
 
     # Collection and image provided
     elif len(image_name) >= 2:
         collection = image_name[0].lower()
-        image_name = image_name[1].lower()
+        image_name = image_name[1]
     
     # Is there a version?
     image_name = image_name.split('@')
     if len(image_name) > 1: 
         version = image_name[1].lower()
-    image_name = image_name[0].lower()
+    image_name = image_name[0]
 
     # Is there a tag?
     image_name = image_name.split(':')

--- a/sregistry/utils/names.py
+++ b/sregistry/utils/names.py
@@ -66,7 +66,7 @@ def parse_image_name(image_name,
         image_name = image_name.replace(base,'').strip('/')
 
     result = dict()
-    image_name = re.sub('[.](img|simg)','',image_name).lower()
+    image_name = re.sub('[.](img|simg)','',image_name)
     image_name = re.split('/', image_name, 1)
 
     # User only provided an image
@@ -74,18 +74,18 @@ def parse_image_name(image_name,
         collection = ''
         if defaults is True:
             collection = default_collection
-        image_name = image_name[0]
+        image_name = image_name[0].lower()
 
     # Collection and image provided
     elif len(image_name) >= 2:
-        collection = image_name[0]
-        image_name = image_name[1]
+        collection = image_name[0].lower()
+        image_name = image_name[1].lower()
     
     # Is there a version?
     image_name = image_name.split('@')
     if len(image_name) > 1: 
-        version = image_name[1]
-    image_name = image_name[0]
+        version = image_name[1].lower()
+    image_name = image_name[0].lower()
 
     # Is there a tag?
     image_name = image_name.split(':')
@@ -93,7 +93,7 @@ def parse_image_name(image_name,
     # No tag in provided string
     if len(image_name) > 1: 
         tag = image_name[1]
-    image_name = image_name[0]
+    image_name = image_name[0].lower()
     
     # If still no tag, use default or blank
     if tag is None and defaults is True:

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -19,7 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.0.88"
+__version__ = "0.0.89"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'


### PR DESCRIPTION
This is a quick PR to ensure that the case of the tag when a URI is parsed is honored (e.g., not all made lowercase). When this PR is merged, it will close #133 and I will upload to pypi as version 0.89 of sregistry. Here is my quick local testing:

```python
from sregistry.utils import parse_image_name

parse_image_name('docker://collection/container:TaG')
Out[2]: 
{'collection': 'docker:',
 'image': '/collection/container',
 'storage': 'docker://collection/container:TaG.simg',
 'tag': 'TaG',
 'uri': 'docker://collection/container:TaG',
 'url': 'docker://collection/container',
 'version': None}
```
Note that the tag variable is not modified from it's glorious `TaG` :) @AdamSimpson would you care to test?