### PR TITLE
Fix registry backend (PUSH)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.0.x)
+ - resolved [bug in registry backend push function](https://github.com/singularityhub/sregistry-cli/issues/137) that stripped wrong char(s) (0.0.94)
  - adding rpm spec file, sregistry.cli.spec (0.0.90,0.0.91)
  - image URI tag should not be changed to lowercase (0.0.89)
  - adding chunked upload to chunk uploads to Singularity Registry (0.0.88)

--- a/sregistry/main/registry/push.py
+++ b/sregistry/main/registry/push.py
@@ -107,8 +107,11 @@ def push(self, path, name, tag=None):
 
     try:
         r = requests.post(url, data=monitor, headers=headers)
+        r.raise_for_status()
         message = r.json()['message']
         print('\n[Return status {0} {1}]'.format(r.status_code, message))
+    except requests.HTTPError as e:
+        print('\nUpload failed: {0}.'.format(e))
     except KeyboardInterrupt:
         print('\nUpload cancelled.')
     except Exception as e:

--- a/sregistry/main/registry/push.py
+++ b/sregistry/main/registry/push.py
@@ -58,7 +58,7 @@ def push(self, path, name, tag=None):
     image_size = os.path.getsize(path) >> 20
 
 # COLLECTION ###################################################################
-    
+
     # Prepare push request, this will return a collection ID if permission
     url = '%s/push/' % self.base
     auth_url = '%s/upload/chunked_upload' % self.base
@@ -71,7 +71,7 @@ def push(self, path, name, tag=None):
                'tag': names['tag']}
 
     headers = { 'Authorization': SREGISTRY_EVENT }
-    
+
     r = requests.post(auth_url, json=fields, headers=headers)
 
     # Always tell the user what's going on!
@@ -85,7 +85,9 @@ def push(self, path, name, tag=None):
 
 # UPLOAD #######################################################################
 
-    url = '%s/upload' % self.base.strip('api/')
+    url = '%s/upload' % self.base.replace('/api','')
+    bot.debug('Seting upload URL to {0}'.format(url))
+
     cid = r.json()['cid']
     upload_to = os.path.basename(names['storage'])
 

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -19,7 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.0.93"
+__version__ = "0.0.94"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'
@@ -75,7 +75,7 @@ INSTALL_BASIC_GOOGLE_COMPUTE = (
 )
 
 INSTALL_BASIC_ALL = (INSTALL_REQUIRES +
-                     INSTALL_BASIC_DROPBOX + 
+                     INSTALL_BASIC_DROPBOX +
                      INSTALL_BASIC_GLOBUS +
                      INSTALL_BASIC_REGISTRY +
                      INSTALL_BASIC_GOOGLE_STORAGE +
@@ -125,7 +125,7 @@ INSTALL_REQUIRES_GOOGLE_COMPUTE = (
 )
 
 INSTALL_REQUIRES_ALL = (INSTALL_REQUIRES +
-                        INSTALL_REQUIRES_DROPBOX + 
+                        INSTALL_REQUIRES_DROPBOX +
                         INSTALL_REQUIRES_REGISTRY +
                         INSTALL_REQUIRES_GOOGLE_COMPUTE +
                         INSTALL_REQUIRES_GOOGLE_STORAGE +


### PR DESCRIPTION
This PR resolves a bug with reggistry pushing that was causing URLs to be mangled iff they ended with any of the characters `api/`. Additionally we handle HTTPErrors from the request calls. 