### PR TITLE
storage names should use - instead of :for tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.0.x)
+ - storage name should use - instead of : to mirror Singularity  (0.0.99)
  - client missing quiet level  (0.0.98)
  - progress bar should respect quiet level  (0.0.97)
  - install of `[all]` includes aws, and containers building based on pypi version  (0.0.96)

--- a/sregistry/utils/names.py
+++ b/sregistry/utils/names.py
@@ -101,7 +101,7 @@ def parse_image_name(image_name,
     uri = "%s/%s" % (collection, image_name)    
     url = uri
     if tag is not None:
-        uri = "%s:%s" % (uri, tag)
+        uri = "%s-%s" % (uri, tag)
     if version is not None:
         uri = "%s@%s" % (uri, version)
 

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.0.98"
+__version__ = "0.0.99"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'


### PR DESCRIPTION
This will default to storage names using `-` instead of `:` for the tag.