### PR TITLE
Adding workaround for boto3 metadata casing, and updating licenses

### DIFF
--- a/docs/clients/s3.md
+++ b/docs/clients/s3.md
@@ -91,8 +91,7 @@ with the container. s3 is also export as the default client. Let's now use the c
 to push the image to the minio endpoint.
 
 ```bash
-sregistry push --name test/ubuntu:latest /root/.singularity/shub/library-ubuntu-latest-latest.simg
-(base) root@c512453bfeed:/code# sregistry push --name test/ubuntu:latest /root/.singularity/shub/library-ubuntu-latest-latest.simg
+$ sregistry push --name test/ubuntu:latest /root/.singularity/shub/library-ubuntu-latest-latest.simg
 Created bucket mybucket
 [client|s3] [database|sqlite:////root/.singularity/sregistry.db]
 [bucket:s3://s3.Bucket(name='mybucket')]

--- a/examples/docker/docker-compose.yml
+++ b/examples/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       links:
         - sregistrycli
     sregistrycli:
-      image: vanessa/sregistry-cli:add_aws-push
+      image: singularityhub/sregistry-cli:0.1.32
       container_name: sregistrycli
       privileged: true
       command: -F /dev/null

--- a/sregistry/__init__.py
+++ b/sregistry/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/auth/secrets.py
+++ b/sregistry/auth/secrets.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/auth/utils.py
+++ b/sregistry/auth/utils.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/client/__init__.py
+++ b/sregistry/client/__init__.py
@@ -2,7 +2,7 @@
 
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by
@@ -353,22 +353,22 @@ def main():
 
     # Does the user want a shell?
     if args.command == "add": from .add import main
-    if args.command == "backend": from .backend import main
-    if args.command == "build": from .build import main
-    if args.command == "get": from .get import main
-    if args.command == "delete": from .delete import main
-    if args.command == "inspect": from .inspect import main
-    if args.command == "images": from .images import main
-    if args.command == "labels": from .labels import main
-    if args.command == "mv": from .mv import main
-    if args.command == "push": from .push import main
-    if args.command == "pull": from .pull import main
-    if args.command == "rename": from .rename import main
-    if args.command == "rm": from .rm import main
-    if args.command == "rmi": from .rmi import main
-    if args.command == "search": from .search import main
-    if args.command == "share": from .share import main
-    if args.command == "shell": from .shell import main
+    elif args.command == "backend": from .backend import main
+    elif args.command == "build": from .build import main
+    elif args.command == "get": from .get import main
+    elif args.command == "delete": from .delete import main
+    elif args.command == "inspect": from .inspect import main
+    elif args.command == "images": from .images import main
+    elif args.command == "labels": from .labels import main
+    elif args.command == "mv": from .mv import main
+    elif args.command == "push": from .push import main
+    elif args.command == "pull": from .pull import main
+    elif args.command == "rename": from .rename import main
+    elif args.command == "rm": from .rm import main
+    elif args.command == "rmi": from .rmi import main
+    elif args.command == "search": from .search import main
+    elif args.command == "share": from .share import main
+    elif args.command == "shell": from .shell import main
 
     # Pass on to the correct parser
     return_code = 0

--- a/sregistry/client/add.py
+++ b/sregistry/client/add.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2016-2018 Vanessa Sochat.
+Copyright (C) 2016-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/client/backend.py
+++ b/sregistry/client/backend.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/client/build.py
+++ b/sregistry/client/build.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/client/delete.py
+++ b/sregistry/client/delete.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2016-2018 Vanessa Sochat.
+Copyright (C) 2016-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/client/get.py
+++ b/sregistry/client/get.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2016-2017 Vanessa Sochat.
+Copyright (C) 2016-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/client/images.py
+++ b/sregistry/client/images.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2016-2018 Vanessa Sochat.
+Copyright (C) 2016-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/client/inspect.py
+++ b/sregistry/client/inspect.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/client/labels.py
+++ b/sregistry/client/labels.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/client/list.py
+++ b/sregistry/client/list.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/client/mv.py
+++ b/sregistry/client/mv.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/client/pull.py
+++ b/sregistry/client/pull.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2016-2017 Vanessa Sochat.
+Copyright (C) 2016-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/client/push.py
+++ b/sregistry/client/push.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/client/rename.py
+++ b/sregistry/client/rename.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/client/rm.py
+++ b/sregistry/client/rm.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/client/rmi.py
+++ b/sregistry/client/rmi.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/client/search.py
+++ b/sregistry/client/search.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/client/share.py
+++ b/sregistry/client/share.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/client/shell.py
+++ b/sregistry/client/shell.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2016-2017 Vanessa Sochat.
+Copyright (C) 2016-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/database/dummy.py
+++ b/sregistry/database/dummy.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/database/models.py
+++ b/sregistry/database/models.py
@@ -2,7 +2,7 @@
 
 models.py: models for a local singularity registry
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/database/sqlite.py
+++ b/sregistry/database/sqlite.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/defaults.py
+++ b/sregistry/defaults.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/logger/message.py
+++ b/sregistry/logger/message.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/logger/namer.py
+++ b/sregistry/logger/namer.py
@@ -2,7 +2,7 @@
 
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/logger/spinner.py
+++ b/sregistry/logger/spinner.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/README.md
+++ b/sregistry/main/README.md
@@ -5,6 +5,7 @@ These are the primary functions for interacting with different kinds of Singular
  - [registry](registry): is specific to an open source [Singularity Registry](https://www.github.com/singularityhub/sregistry). This is set up by an institution and there are permissions to pull, push, and interact directly with the registry.
  - [hub](hub): is specific to the freely available and open source [Singularity Hub](https://www.singularity-hub.org). You can't directly push, but building is done through Github.
 
+Each other subfolder corresponds to the intended client, see [the documentation](https://singularityhub.github.io/sregistry-cli/clients) for a full list with client tutorials.
 
 ## Adding a Registry
 

--- a/sregistry/main/__init__.py
+++ b/sregistry/main/__init__.py
@@ -4,7 +4,7 @@ This is a base client that imports functions depending on the API it is
     using. Currently, it supports singularity hub and registry, with default
     to use Singularity Hub.
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/__template__/__init__.py
+++ b/sregistry/main/__template__/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/__template__/pull.py
+++ b/sregistry/main/__template__/pull.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/__template__/push.py
+++ b/sregistry/main/__template__/push.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/__template__/query.py
+++ b/sregistry/main/__template__/query.py
@@ -2,7 +2,7 @@
 
 search and query functions for client
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/aws/__init__.py
+++ b/sregistry/main/aws/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/aws/api.py
+++ b/sregistry/main/aws/api.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/aws/pull.py
+++ b/sregistry/main/aws/pull.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/base/__init__.py
+++ b/sregistry/main/base/__init__.py
@@ -2,7 +2,7 @@
 
 sregistry.api: base template for making a connection to an API
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/base/auth.py
+++ b/sregistry/main/base/auth.py
@@ -2,7 +2,7 @@
 
 sregistry.api: base template for making a connection to an API
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/base/headers.py
+++ b/sregistry/main/base/headers.py
@@ -2,7 +2,7 @@
 
 sregistry.api: base template for making a connection to an API
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/base/http.py
+++ b/sregistry/main/base/http.py
@@ -2,7 +2,7 @@
 
 sregistry.api: base template for making a connection to an API
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/base/inspect.py
+++ b/sregistry/main/base/inspect.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/base/settings.py
+++ b/sregistry/main/base/settings.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/docker/__init__.py
+++ b/sregistry/main/docker/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/docker/api.py
+++ b/sregistry/main/docker/api.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2016-2018 Vanessa Sochat.
+Copyright (C) 2016-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/docker/pull.py
+++ b/sregistry/main/docker/pull.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/dropbox/__init__.py
+++ b/sregistry/main/dropbox/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/dropbox/pull.py
+++ b/sregistry/main/dropbox/pull.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/dropbox/push.py
+++ b/sregistry/main/dropbox/push.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/dropbox/query.py
+++ b/sregistry/main/dropbox/query.py
@@ -2,7 +2,7 @@
 
 ls: search and query functions for client
 
-Copyright (C) 2017 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/dropbox/share.py
+++ b/sregistry/main/dropbox/share.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/gitlab/__init__.py
+++ b/sregistry/main/gitlab/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/gitlab/pull.py
+++ b/sregistry/main/gitlab/pull.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/gitlab/query.py
+++ b/sregistry/main/gitlab/query.py
@@ -1,8 +1,6 @@
 '''
 
-ls: search and query functions for client
-
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/globus/__init__.py
+++ b/sregistry/main/globus/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/globus/pull.py
+++ b/sregistry/main/globus/pull.py
@@ -2,7 +2,7 @@
 
 pull.py: pull function for singularity registry
 
-Copyright (C) 2017 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/globus/push.py
+++ b/sregistry/main/globus/push.py
@@ -2,7 +2,7 @@
 
 push.py: push functions for sregistry client
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/globus/query.py
+++ b/sregistry/main/globus/query.py
@@ -2,7 +2,7 @@
 
 ls: search and query functions for client
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/globus/utils.py
+++ b/sregistry/main/globus/utils.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/google_drive/__init__.py
+++ b/sregistry/main/google_drive/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/google_drive/pull.py
+++ b/sregistry/main/google_drive/pull.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/google_drive/push.py
+++ b/sregistry/main/google_drive/push.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/google_drive/query.py
+++ b/sregistry/main/google_drive/query.py
@@ -2,7 +2,7 @@
 
 search and query functions for client
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/google_drive/share.py
+++ b/sregistry/main/google_drive/share.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/google_drive/utils.py
+++ b/sregistry/main/google_drive/utils.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/google_storage/__init__.py
+++ b/sregistry/main/google_storage/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/google_storage/build.py
+++ b/sregistry/main/google_storage/build.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/google_storage/delete.py
+++ b/sregistry/main/google_storage/delete.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/google_storage/logs.py
+++ b/sregistry/main/google_storage/logs.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/google_storage/pull.py
+++ b/sregistry/main/google_storage/pull.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/google_storage/push.py
+++ b/sregistry/main/google_storage/push.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/google_storage/query.py
+++ b/sregistry/main/google_storage/query.py
@@ -2,7 +2,7 @@
 
 ls: search and query functions for client
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/google_storage/utils.py
+++ b/sregistry/main/google_storage/utils.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/hub/__init__.py
+++ b/sregistry/main/hub/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/hub/pull.py
+++ b/sregistry/main/hub/pull.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/hub/query.py
+++ b/sregistry/main/hub/query.py
@@ -2,7 +2,7 @@
 
 search and query functions for client
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/nvidia/__init__.py
+++ b/sregistry/main/nvidia/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/nvidia/pull.py
+++ b/sregistry/main/nvidia/pull.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/registry/__init__.py
+++ b/sregistry/main/registry/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/registry/auth.py
+++ b/sregistry/main/registry/auth.py
@@ -2,7 +2,7 @@
 
 auth.py: authorization functions for client
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/registry/delete.py
+++ b/sregistry/main/registry/delete.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/registry/pull.py
+++ b/sregistry/main/registry/pull.py
@@ -2,7 +2,7 @@
 
 pull.py: pull function for singularity registry
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/registry/push.py
+++ b/sregistry/main/registry/push.py
@@ -2,7 +2,7 @@
 
 push.py: push functions for sregistry client
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/registry/query.py
+++ b/sregistry/main/registry/query.py
@@ -2,7 +2,7 @@
 
 search and query functions for client
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/registry/utils.py
+++ b/sregistry/main/registry/utils.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/s3/__init__.py
+++ b/sregistry/main/s3/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/s3/pull.py
+++ b/sregistry/main/s3/pull.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by
@@ -90,7 +90,12 @@ def pull(self, images, file_name=None, save=True, **kwargs):
         # If we find the object, get metadata
         metadata = {}
         if found != None:
-            metadata = found.get()['Metadata']       
+            metadata = found.get()['Metadata']
+
+            # Metadata bug will capitalize all fields, workaround is to lowercase
+            # https://github.com/boto/boto3/issues/1709
+            metadata = dict((k.lower(), v) for k, v in metadata.items())
+  
         metadata.update(names)
 
         # If the user is saving to local storage

--- a/sregistry/main/s3/push.py
+++ b/sregistry/main/s3/push.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by
@@ -43,6 +43,8 @@ def push(self, path, name, tag=None):
     image_size = os.path.getsize(path) >> 20
 
     # Create extra metadata, this is how we identify the image later
+    # *important* bug in boto3 will return these capitalized
+    # see https://github.com/boto/boto3/issues/1709
     metadata = {'sizemb': "%s" % image_size,
                 'client': 'sregistry' }
 

--- a/sregistry/main/s3/query.py
+++ b/sregistry/main/s3/query.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by
@@ -43,9 +43,9 @@ def search(self, query=None, args=None):
 
 
 
-##################################################################
+################################################################################
 # Search Helpers
-##################################################################
+################################################################################
 
 def search_all(self, quiet=False):
     '''a "show all" search that doesn't require a query
@@ -60,6 +60,10 @@ def search_all(self, quiet=False):
 
     for obj in self.bucket.objects.all():
        subsrc = obj.Object()
+
+       # Metadata bug will capitalize all fields, workaround is to lowercase
+       # https://github.com/boto/boto3/issues/1709
+       metadata = dict((k.lower(), v) for k, v in subsrc.metadata.items())
        size = ''
 
        # MM-DD-YYYY
@@ -67,8 +71,8 @@ def search_all(self, quiet=False):
                               obj.last_modified.day,
                               obj.last_modified.year)
 
-       if 'sizemb' in subsrc.metadata:
-           size = '%sMB' % subsrc.metadata['sizemb']
+       if 'sizemb' in metadata:
+           size = '%sMB' % metadata['sizemb']
 
        results.append([obj.key, datestr, size ])
    

--- a/sregistry/main/swift/__init__.py
+++ b/sregistry/main/swift/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/swift/pull.py
+++ b/sregistry/main/swift/pull.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/swift/push.py
+++ b/sregistry/main/swift/push.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/swift/query.py
+++ b/sregistry/main/swift/query.py
@@ -2,7 +2,7 @@
 
 ls: search and query functions for client
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/templates/build/singularity-builder-apt.sh
+++ b/sregistry/main/templates/build/singularity-builder-apt.sh
@@ -7,7 +7,7 @@
 #                   All other APIs None,
 #
 #
-# Copyright (C) 2018 Vanessa Sochat.
+# Copyright (C) 2018-2019 Vanessa Sochat.
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/workers/__init__.py
+++ b/sregistry/main/workers/__init__.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/workers/aws.py
+++ b/sregistry/main/workers/aws.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 These are aws tasks.
 

--- a/sregistry/main/workers/tasks.py
+++ b/sregistry/main/workers/tasks.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/main/workers/worker.py
+++ b/sregistry/main/workers/worker.py
@@ -2,7 +2,7 @@
 
 sregistry.api: base template for making a connection to an API
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/utils/cache.py
+++ b/sregistry/utils/cache.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/utils/fileio.py
+++ b/sregistry/utils/fileio.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/utils/names.py
+++ b/sregistry/utils/names.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/utils/recipes.py
+++ b/sregistry/utils/recipes.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/utils/templates.py
+++ b/sregistry/utils/templates.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/utils/terminal.py
+++ b/sregistry/utils/terminal.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2017-2018 Vanessa Sochat.
+Copyright (C) 2017-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.1.31"
+__version__ = "0.1.32"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'


### PR DESCRIPTION
This pull request will address the following:

 - #170 the boto3 client doesn't honor the metadata casing that we define, for example, defining "sizemb" as a key is returning as "Sizemb." As a workaround, we need to parse the keys (and lowercase) in advance before further interaction.
 - #171 licenses are updated to 2019
 - The docker-compose file uses the testing container (vanessa/sregistry-cli) instead of the deployed singularityhub/sregistry-cli.
 - a bug in the documentation for "minio push" had a repeated line.

@fenz would you care to test? For the docker-compose, you will need to change the tag to be the automated build to `vanessa/sregistry-cli` from this branch - the one that I changed it to will be the container deployed after merge :)