### PR TITLE
Add Keystone authentication support for Swift client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.0.x)
+ - added keystone authetication support to swift backend (0.01.33)
  - renaming ceph to swift, no other changes  (0.01.03)
  - adding ceph as backend to push, pull  (0.01.02)
  - adding GitLab Backend  (0.01.01)

--- a/docs/clients/swift.md
+++ b/docs/clients/swift.md
@@ -38,6 +38,12 @@ pip install sregistry
 pip install python-swiftclient
 ```
 
+If your environment uses Openstack Keystone for authentication, you need to add the Keystone client
+
+```bash
+pip install python-keystoneclient
+```
+
 The next steps we will take are to first set up authentication and other 
 environment variables of interest, and then review the basic usage.
 
@@ -116,6 +122,62 @@ means that I would export `http://172.17.0.1:8080` as the endpoint for the API.
 The port must be included too because most setups will have either a different port
 or a proxy that hides it entirely.
 
+### Keystone Authentication
+
+There are threee supported modes for authentication against Keystone - Keystone V3, 
+Keystone V2, and Pre-Authenticated Token Access. The mode is requested by setting
+SREGISTRY_SWIFT_AUTHTYPE environment variable.
+
+```bash
+export SREGISTRY_SWIFT_AUTHTYPE=keystonev3 - For Keystone V3
+export SREGISTRY_SWIFT_AUTHTYPE=keystonev2 - For Keystone V2
+export SREGISTRY_SWIFT_AUTHTYPE=preauth - For Token based authentication
+```
+Keystone V2 and V3 authentication requires the user to go through the 
+process of authenticating against Keystone before the client is allowed
+to communicate with the object storage service.
+
+Token based authentication requires the user to authenticate once against
+Keystone to collect an authenticated token and storage URL to the tenant.
+This provides quicker access to the images in object storage.
+ 
+Each type of access has several requireed environment variables to pass in the 
+required parameters to the swift client connection routine.
+
+#### Keystone V3 parameters
+
+The required parameters to use V3 authentication are:
+
+```bash
+export SREGISTRY_SWIFT_USER=<username>
+export SREGISTRY_SWIFT_TOKEN=<password> - Password or token for <username>
+export SREGSITRY_SWIFT_URL=<URL to Keystone Service>
+```
+This is currently just a placeholder as the functionality has not been validated
+
+#### Keystone V2 parameters
+
+The required parameters to use V2 authentication are:
+
+```bash
+export SREGISTRY_SWIFT_USER=<username>
+export SREGISTRY_SWIFT_TOKEN=<password> - Password or token for <username>
+export SREGSITRY_SWIFT_URL=<URL to Keystone Service>
+export SREGSITRY_SWIFT_TENANT=<tenant name>
+export SREGSITRY_SWIFT_REGION=<region name that contains the tenant>
+```
+
+#### Token authentication parameters
+
+The required parameters to use V2 authentication are:
+
+```bash
+export SREGISTRY_SWIFT_OS_AUTH_TOKEN=<pre-authenicated token>
+export SREGISTRY_SWIFT_OS_STORAGE_URL=<authenticated storage URL>
+```
+The SREGISTRY_SWIFT_OS_AUTH_TOKEN and SREGISTRY_SWIFT_OS_STORAGE_URL 
+are completely different from the SREGISTRY_SWIFT_TOKEN and
+SREGISTRY_SWIFT_URL
 
 ## sregistry push
 We've just exported our environment variables for our Ceph Storage, now let's

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.1.32"
+__version__ = "0.1.33"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'
@@ -52,6 +52,7 @@ INSTALL_BASIC_AWS = (
 
 INSTALL_BASIC_SWIFT = (
     ('python-swiftclient', {'min_version': '3.6.0'}),
+    ('python-keystoneclient', {'min_version': '3.5.0'}),
     ('oauth2client', {'min_version': '3.0'}),
 )
 INSTALL_BASIC_DROPBOX = (


### PR DESCRIPTION
The swift client support only used Legacy Authentication per [The swiftclient.Connection API](https://docs.openstack.org/python-swiftclient/latest/client-api.html)
docs. This does not work for environments that use Openstack Keystone as a 
centralized authentication service.  This change implements the support for 
Keystone V2 and V3 authentication along with Openstack's Pre-Authenticated 
Token access to object storage.

To enable this support, we require several additional parameters:

SREGISTRY_SWIFT_AUTHTYPE: Defines the type of authentication
        Expected Values: 'preauth', 'keystonev3', 'keystonev2',
                                   or blank (Legacy Auth)

Required variables for 'preauth" authentication type"
SREGISTRY_SWIFT_OS_AUTH_TOKEN: Token Pre-Authentication access - Different
                                                         token from the SREGISTRY_SWIFT_TOKEN
SREGISTRY_SWIFT_OS_STORAGE_URL: Authenticated URL to access the bucket
                                                          directly.  This is not the URL to authenticate

Required variables for 'keystonev3' authentication:
SREGISTRY_SWIFT_USER - Username that is authenicating against Keystone
SREGISTRY_SWIFT_TOKEN - User Password/Token for the specified user
SREGISTRY_SWIFT_URL - URL for the Keystone authentication service

Required variables for 'keystonev2' authentication:
SREGISTRY_SWIFT_USER - Username that is authenicating against Keystone
SREGISTRY_SWIFT_TOKEN - User Password/Token for the specified user
SREGISTRY_SWIFT_URL - URL for the Keystone authentication service
SREGISTRY_SWIFT_TENANT - Tenant Name in keystone that the user has access to
SREGISTRY_SWIFT_REGION - The region that the tenant is stored in

Required variables for legacy authentication:
SREGISTRY_SWIFT_USER - Username that is authenicating against the object store
SREGISTRY_SWIFT_TOKEN - User Password/Token for the specified user
SREGISTRY_SWIFT_URL - URL for the object storage authentication service

Added documentation to describe how to use Keystone v2/v3 and
per-authenticated token access.