### PR TITLE
Add support for older S3 v2 signatures

### DIFF
--- a/docs/clients/s3.md
+++ b/docs/clients/s3.md
@@ -149,6 +149,19 @@ or for a more permanent default, set it like this:
 $ sregistry backend activate s3
 [activate] s3
 ```
+### Optional Parameter
+S3 Signature version
+
+Some environments may not support the current S3 v4 client signature.  If you need to use the older
+S3 v2 signature, you can specify the desired signature using the SREGISTRY_S3_SIGNATURE variable.
+This parameter is optional.  If you do not specify the signatureor specify anything other than
+a S3 v2 signature, sregistry-cli defaults to 's3v4'
+
+To use a S3 v2 signature:
+
+```bash
+export SREGISTRY_S3_SIGNATURE=s3
+```
 
 ## Push
 

--- a/sregistry/main/s3/__init__.py
+++ b/sregistry/main/s3/__init__.py
@@ -116,7 +116,8 @@ class Client(ApiConnection):
             self.s3 = boto3.resource('s3',
                                      endpoint_url=self.base,
                                      aws_access_key_id=self._id,
-                                     aws_secret_access_key=self._key)
+                                     aws_secret_access_key=self._key,
+                                     config=boto3.session.Config(signature_version=self._signature))
         else:
            # We will need to test options for reading credentials here
            self.s3 = boto3.client('s3')
@@ -131,6 +132,17 @@ class Client(ApiConnection):
         self.base = self._get_and_update_setting('SREGISTRY_S3_BASE', self.base)
         self._id = self._required_get_and_update('AWS_ACCESS_KEY_ID')
         self._key = self._required_get_and_update('AWS_SECRET_ACCESS_KEY')
+
+        # Get the desired S3 signature.  Default is the current "s3v4" signature.
+        # If specified, user can request "s3" (v2 old) signature
+        self._signature = self._get_and_update_setting('SREGISTRY_S3_SIGNATURE')
+
+        if self._signature == 's3':
+            # Requested signature is S3 V2
+            self._signature = 's3'
+        else:
+            # self._signature is not set or not set to s3 (v2), default to s3v4
+            self._signature = 's3v4'
 
         # Define self.bucket_name, self.s3, then self.bucket
         self.get_bucket_name()

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.1.34"
+__version__ = "0.1.35"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'


### PR DESCRIPTION
Boto3 defaults to using the current s3v4 client signatures when connecting to an S3 object storage service.  While deprecated at AWS, some environments still require the use of the older S3 V2 (s3) client signatures.  

This PR adds an optional environment variable (SREGISTRY_S3_SIGNATURE) that allows a user to specify the use of the v2 signatures (SREGISTRY_S3_SIGNATURE=s3), or default to the current s3v4 signature.  

If a user does not set the SREGISTRY_S3_SIGNATURE variable, the s3 client will use s3v4 signatures, which is the current behavior.  If anything OTHER than "s3" is specified, the s3 client will use s3v4.

This change is required to allow us to use S3 client support in our current on-premise environment.  This change has been tested and the various use cases work as described.