### PR TITLE
Swift client AUTHTYPE env variables match documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.0.x)
+ - swift client ENV variable handling matches documentation (0.1.36)
+ - s3 client supports S3 V2 (old) and S3 V4 (current) signatures (0.1.35)
  - fixed upload to google-storage bug with metadata (0.01.34)
  - added keystone authetication support to swift backend (0.01.33)
  - renaming ceph to swift, no other changes  (0.01.03)

--- a/sregistry/main/swift/__init__.py
+++ b/sregistry/main/swift/__init__.py
@@ -82,13 +82,8 @@ class Client(ApiConnection):
 
         # Get the swift authentication type first.  That will determine what we
         # will need to collect for proper authentication
-        self.config['SREGISTRY_SWIFT_AUTHTYPE'] = self._get_and_update_setting(
+        self.config['SREGISTRY_SWIFT_AUTHTYPE'] = self._required_get_and_update(
                                                      'SREGISTRY_SWIFT_AUTHTYPE')
-
-        # Check that authtype is set
-        if self.config['SREGISTRY_SWIFT_AUTHTYPE'] is None:
-            bot.error('You must export SREGISTRY_SWIFT_AUTHTYPE to use client.')
-            sys.exit(1)
 
         # Check what auth version is requested and setup the connection
         if self.config['SREGISTRY_SWIFT_AUTHTYPE'] == 'preauth':
@@ -97,12 +92,7 @@ class Client(ApiConnection):
             # Retrieve the user token, user, and base. Exit if not found 
             for envar in ['SREGISTRY_SWIFT_OS_AUTH_TOKEN',
                           'SREGISTRY_SWIFT_OS_STORAGE_URL' ]:
-                self.config[envar] = self._get_and_update_setting(envar)
-
-                # All variables are required
-                if self.config[envar] is None:
-                    bot.error('You must export %s to use client.' % envar)
-                    sys.exit(1)
+                self.config[envar] = self._required_get_and_update(envar)
 
             self.conn = swiftclient.Connection(
                 preauthurl=self.config['SREGISTRY_SWIFT_OS_STORAGE_URL'],
@@ -115,12 +105,7 @@ class Client(ApiConnection):
             for envar in ['SREGISTRY_SWIFT_USER',
                           'SREGISTRY_SWIFT_TOKEN',
                           'SREGISTRY_SWIFT_URL']:
-                self.config[envar] = self._get_and_update_setting(envar)
-
-                # All variables are required
-                if self.config[envar] is None:
-                    bot.error('You must export %s to use client.' % envar)
-                    sys.exit(1)
+                self.config[envar] = self._required_get_and_update(envar)
 
             auth_url = '%s/v3' % self.config['SREGISTRY_SWIFT_URL']
             # Setting to default as a safety.  No v3 environment to test
@@ -149,12 +134,7 @@ class Client(ApiConnection):
                           'SREGISTRY_SWIFT_TENANT',
                           'SREGISTRY_SWIFT_REGION',
                           'SREGISTRY_SWIFT_URL']:
-                self.config[envar] = self._get_and_update_setting(envar)
-
-                # All variables are required
-                if self.config[envar] is None:
-                    bot.error('You must export %s to use client.' % envar)
-                    sys.exit(1)
+                self.config[envar] = self._required_get_and_update(envar)
 
             # More human friendly to interact with
             auth_url = '%s/v2.0/' % self.config['SREGISTRY_SWIFT_URL']
@@ -179,12 +159,7 @@ class Client(ApiConnection):
             for envar in ['SREGISTRY_SWIFT_USER',
                           'SREGISTRY_SWIFT_TOKEN',
                           'SREGISTRY_SWIFT_URL']:
-                self.config[envar] = self._get_and_update_setting(envar)
-
-                # All variables are required
-                if self.config[envar] is None:
-                    bot.error('You must export %s to use client.' % envar)
-                    sys.exit(1)
+                self.config[envar] = self._required_get_and_update(envar)
 
             # More human friendly to interact with
             auth_url = '%s/auth/' % self.config['SREGISTRY_SWIFT_URL']

--- a/sregistry/main/swift/__init__.py
+++ b/sregistry/main/swift/__init__.py
@@ -80,31 +80,48 @@ class Client(ApiConnection):
            If we find the values, cache and continue. Otherwise, exit with error
         '''
 
-        # Retrieve the user token, user, and base. Exit if not found 
-        for envar in ['SREGISTRY_SWIFT_AUTHTYPE',
-                      'SREGISTRY_SWIFT_OS_AUTH_TOKEN',
-                      'SREGISTRY_SWIFT_OS_STORAGE_URL',
-                      'SREGISTRY_SWIFT_USER',
-                      'SREGISTRY_SWIFT_TOKEN',
-                      'SREGISTRY_SWIFT_TENANT',
-                      'SREGISTRY_SWIFT_REGION',
-                      'SREGISTRY_SWIFT_URL']:
-            self.config[envar] = self._get_and_update_setting(envar)
+        # Get the swift authentication type first.  That will determine what we
+        # will need to collect for proper authentication
+        self.config['SREGISTRY_SWIFT_AUTHTYPE'] = self._get_and_update_setting(
+                                                     'SREGISTRY_SWIFT_AUTHTYPE')
 
-            # All variables are required
-            if self.config[envar] is None:
-                bot.error('You must export %s to use client.' % envar)
-                sys.exit(1)
+        # Check that authtype is set
+        if self.config['SREGISTRY_SWIFT_AUTHTYPE'] is None:
+            bot.error('You must export SREGISTRY_SWIFT_AUTHTYPE to use client.')
+            sys.exit(1)
 
         # Check what auth version is requested and setup the connection
         if self.config['SREGISTRY_SWIFT_AUTHTYPE'] == 'preauth':
+
             # Pre-Authenticated Token/URL - Use OS_AUTH_TOKEN/OS_STORAGE_URL
+            # Retrieve the user token, user, and base. Exit if not found 
+            for envar in ['SREGISTRY_SWIFT_OS_AUTH_TOKEN',
+                          'SREGISTRY_SWIFT_OS_STORAGE_URL' ]:
+                self.config[envar] = self._get_and_update_setting(envar)
+
+                # All variables are required
+                if self.config[envar] is None:
+                    bot.error('You must export %s to use client.' % envar)
+                    sys.exit(1)
+
             self.conn = swiftclient.Connection(
                 preauthurl=self.config['SREGISTRY_SWIFT_OS_STORAGE_URL'],
                 preauthtoken=self.config['SREGISTRY_SWIFT_OS_AUTH_TOKEN']
             )
         elif self.config['SREGISTRY_SWIFT_AUTHTYPE'] == 'keystonev3':
+
             # Keystone v3 Authentication
+            # Retrieve the user token, user, and base. Exit if not found 
+            for envar in ['SREGISTRY_SWIFT_USER',
+                          'SREGISTRY_SWIFT_TOKEN',
+                          'SREGISTRY_SWIFT_URL']:
+                self.config[envar] = self._get_and_update_setting(envar)
+
+                # All variables are required
+                if self.config[envar] is None:
+                    bot.error('You must export %s to use client.' % envar)
+                    sys.exit(1)
+
             auth_url = '%s/v3' % self.config['SREGISTRY_SWIFT_URL']
             # Setting to default as a safety.  No v3 environment to test
             # May require ENV vars for real use. - M. Moore
@@ -124,7 +141,21 @@ class Client(ApiConnection):
             )
 
         elif self.config['SREGISTRY_SWIFT_AUTHTYPE'] == 'keystonev2':
+
             # Keystone v2 Authentication
+            # Retrieve the user token, user, and base. Exit if not found 
+            for envar in ['SREGISTRY_SWIFT_USER',
+                          'SREGISTRY_SWIFT_TOKEN',
+                          'SREGISTRY_SWIFT_TENANT',
+                          'SREGISTRY_SWIFT_REGION',
+                          'SREGISTRY_SWIFT_URL']:
+                self.config[envar] = self._get_and_update_setting(envar)
+
+                # All variables are required
+                if self.config[envar] is None:
+                    bot.error('You must export %s to use client.' % envar)
+                    sys.exit(1)
+
             # More human friendly to interact with
             auth_url = '%s/v2.0/' % self.config['SREGISTRY_SWIFT_URL']
             # Set required OpenStack options for tenant/region
@@ -142,7 +173,19 @@ class Client(ApiConnection):
                 auth_version='2'
             )
         else:
+
             # Legacy Authentication
+            # Retrieve the user token, user, and base. Exit if not found 
+            for envar in ['SREGISTRY_SWIFT_USER',
+                          'SREGISTRY_SWIFT_TOKEN',
+                          'SREGISTRY_SWIFT_URL']:
+                self.config[envar] = self._get_and_update_setting(envar)
+
+                # All variables are required
+                if self.config[envar] is None:
+                    bot.error('You must export %s to use client.' % envar)
+                    sys.exit(1)
+
             # More human friendly to interact with
             auth_url = '%s/auth/' % self.config['SREGISTRY_SWIFT_URL']
 

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.1.35"
+__version__ = "0.1.36"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'


### PR DESCRIPTION
Hi @vsoch 

The original fix to introduce the multiple authentication types for the swift client support loaded the environment variables incorrectly.  Every SREGISTRY_SWIFT_AUTHTYPE case required the user to set ALL SREGISTRY_SWIFT_<> variables.  The documentation indicated that each case required a different set of variables.  

This PR reworks the environment variable loading to match what the documentation requires.  I missed this issue during testing because I had all of the environment variables set during development, and once everything was working, the variables were cached in ~/.sregistry.  There is no functional difference to swift client calls, just how __init__.py loads the required variables.
