### PR TITLE
fixing bug that the registry api base needs to end with api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.0.x)
+ - bug with sregistry push api endpoint, needs to end with api (0.01.41)
  - docker auth is undefined, and storage attribute needs to be checked for naming (0.01.40)
  - fixing bug with tag specification for registry pull (0.01.39)
  - registry client should honor base, if provided with uri (0.01.38)

--- a/sregistry/main/registry/__init__.py
+++ b/sregistry/main/registry/__init__.py
@@ -31,8 +31,9 @@ class Client(ApiConnection):
 
     def _update_base(self):
         if self.base is not None:
+            self.base = self.base.strip('/')
             if not self.base.endswith('api'):
-                self.base = self.base.strip('/')
+                self.base = "%s/api" % self.base
 
 
     def _read_response(self,response, field="detail"):

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 '''
 
-__version__ = "0.1.40"
+__version__ = "0.1.41"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'


### PR DESCRIPTION
This will fix #195 , specifically the collection permission check URL was (incorrectly) using the upload url, which expects (as the error suggests) multipart form data in the way of the container binary. The fix was to restore the check that the client url ends with api.

After removing all previous versions:

```bash
$ pip uninstall sregistry
```
(do that until it says not installed)

You can clone this branch, and install to test:

```bash
git clone -b fix/bug-api-base https;//www.github.com/singularityhub/sregistry-cli
cd sregistry-cli
python setup.py install
SREGISTRY_CLIENT=registry sregistry push --name mycollection/salad:latest salad_latest.sif
```

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>