### PR TITLE
S3: fix bug when self.base == None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.0.x)
+ - fix s3 client support when SREGISTRY_S3_BASE is not specified, and allow for IAM accounts that do not permit listing buckets (0.2.1)
  - remove dateutils to allow conda support, 0.1.41 will be last supported for Python 2 (0.2.0)
  - bug with sregistry push api endpoint, needs to end with api (0.1.41)
  - docker auth is undefined, and storage attribute needs to be checked for naming (0.1.40)

--- a/sregistry/main/s3/__init__.py
+++ b/sregistry/main/s3/__init__.py
@@ -75,11 +75,10 @@ class Client(ApiConnection):
             if not hasattr(self, attr):
                 bot.exit('client is missing attribute %s' %(attr))
 
-        # See if the bucket is already existing
-        self.bucket = None
-        for bucket in self.s3.buckets.all():
-            if bucket.name == self.bucket_name:
-                self.bucket = bucket
+        self.bucket = self.s3.Bucket(self.bucket_name)
+        # See if the bucket is already existing by checking the creation_date
+        if self.bucket.creation_date is None:
+            self.bucket = None
  
         # If the bucket doesn't exist, create it
         if self.bucket is None:
@@ -100,19 +99,12 @@ class Client(ApiConnection):
            https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
         '''
 
-        # If base is not defined, assume using aws client
-        if self.base != None:
-
-            # s3.ServiceResource()
-            self.s3 = boto3.resource('s3',
-                                     endpoint_url=self.base,
-                                     aws_access_key_id=self._id,
-                                     aws_secret_access_key=self._key,
-                                     config=boto3.session.Config(signature_version=self._signature))
-        else:
-           # We will need to test options for reading credentials here
-           self.s3 = boto3.client('s3')
-
+        # s3.ServiceResource()
+        self.s3 = boto3.resource('s3',
+                                 endpoint_url=self.base,
+                                 aws_access_key_id=self._id,
+                                 aws_secret_access_key=self._key,
+                                 config=boto3.session.Config(signature_version=self._signature))
 
 
     def _update_secrets(self, base=None):

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 '''
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'


### PR DESCRIPTION
boto3.client and boto3.resource return different types of objects and
only the latter in the latter case does the returned instance have a
buckets attribute.
This patch uses boto3.resource regardless of self.base being set, which
works fine.
It will now also appropriately deal with IAM policies that do not allow
its user to retrieve the list of buckets, and will instead check
directly if the bucket named $SREGISTRY_S3_BUCKET exists or not.