### PR TITLE
updating organization of containers, and adding different versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.0.x)
+ - images being added twice (0.2.16)
  - adding pylint, and destroy function back to Google Storage (for instances) (0.2.15)
  - fixing bug with deleting container for Google Storage and Google Build (0.2.14)
  - ensure non-zero return values are returned when necessary (0.2.13)

--- a/sregistry/main/base/settings.py
+++ b/sregistry/main/base/settings.py
@@ -115,17 +115,17 @@ def get_storage_name(self, names, remove_dir=False):
        Parameters
        ==========
        names: the output from parse_image_name
-    '''
-    storage_folder = os.path.dirname(names['storage'])
+    '''   
+    storage_folder = os.path.join(names['collection'], names['image'])
+    storage_filename = names['storage_uri'].replace(storage_folder, '', 1).strip(':')
 
     # If the client doesn't have a database, default to PWD
     if not hasattr(self, 'storage'):
-        return os.path.basename(names['storage'])
+        return os.path.basename(names['storage_uri'])
         
-    storage_folder = "%s/%s" %(self.storage, storage_folder)
+    storage_folder = os.path.join(self.storage, storage_folder)
     mkdir_p(storage_folder)
-    file_name = names['storage'].replace('/','-')
-    storage_path = "%s/%s" %(self.storage, file_name)
-    if remove_dir is True:
-        return file_name
+    storage_path = os.path.join(storage_folder, storage_filename)
+    if remove_dir:
+        return storage_filename
     return storage_path

--- a/sregistry/utils/names.py
+++ b/sregistry/utils/names.py
@@ -119,7 +119,7 @@ def parse_image_name(image_name,
     collection = match.group('collection')
     repo_name = match.group('repo')
     repo_tag = match.group('tag')
-    version = match.group('version')
+    version = version or match.group('version')
     
     # A repo_name is required
     assert repo_name

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 '''
 
-__version__ = "0.2.15"
+__version__ = "0.2.16"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'


### PR DESCRIPTION
This pull request will close #214 , specifically when the user adds a "same" container (different file / version) the filename is added to the database organized by container collection, name, and then tag and version.

Here we see images 3 and 4, both just added (different files so different versions)
```
$ sregistry images
Containers:   [date]   [client]	[uri]
1  June 04, 2019	   [hub]	my-library/my-image:latest@407e58c8295f495498df03cbf479f0de
2  June 04, 2019	   [hub]	my-library/my-image:latest@7a7522e617d3e010a00c10d4016d4a0e
3  June 04, 2019	   [google-compute]	vanessa/busybox:latest@2c656dfd4b70157d326170821a10fa9e
4  June 04, 2019	   [google-compute]	vanessa/busybox:latest@38d45ecf29e428fc40a27ad48fba6367
```
Here is how they are kept in storage, cleaner / clearer than before:

```bash
$ ls /home/vanessa/.singularity/shub/vanessa/busybox/
latest@2c656dfd4b70157d326170821a10fa9e.sif  latest@38d45ecf29e428fc40a27ad48fba6367.sif
```
And when we do a get, we return the first result:

```bash
$ sregistry get vanessa/busybox
/home/vanessa/.singularity/shub/vanessa/busybox/latest@2c656dfd4b70157d326170821a10fa9e.sif
```

@tschoonj mentioned not keeping different versions but asking the user to use --force, and I can imagine users (that do want versions) would have issue with that.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>