### PR TITLE
Add working directory to build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.0.x)
+ - adding ability to specify working_dir for Google Cloud Build (0.2.21)
  - finalizing registry Google Cloud Builder (0.2.20)
  - adding sregistry build to push recipes for Google Cloud (or other) builder (0.2.19)
  - ensure sregistry exits gracefully when database cannot be created (0.2.18)

--- a/docs/pages/clients/google-build.md
+++ b/docs/pages/clients/google-build.md
@@ -69,6 +69,7 @@ Let's get off to a running start and build! We have two options for building:
 
  1. Build from a Local Recipe
  2. Build from a GitHub repository
+ 3. More Complicated Builds
 
 The second is recommended, as it is more reproducible, but there are use cases for
 both.
@@ -305,7 +306,26 @@ If you have a context, just specify it.
                           context=context)
 ```
 
-The output will be the same as shown previously. You are again encouraged to look at the logs
+Or if you want to specify a different working directory (that is removed
+from the path of the recipe and any files provided with "context" you can do
+that too:
+
+
+```python
+
+> recipe = "/tmp/test/Singularity"      
+> name = 'vanessa/avocados'
+
+> response = client.build(name=name,
+                          recipe=recipe,
+                          working_dir="/tmp/test")
+
+```
+
+In the above example, we want the builder's present working directory to be
+`/tmp/test`, so the recipe will be stripped of this path. If you are building
+with a recipe that is a relative path or in the present working directory,
+you shouldn't need to do this given that the builder expects the same path. The output will be the same as shown previously. You are again encouraged to look at the logs
 link if the build isnt' a success. With the interactive shell mode, you can also provide the `preview` argument to just inspect the configuration for the build: 
 
 ```bash
@@ -385,6 +405,48 @@ from Github:
 You'll notice that the first step is to clone the repository. If we provided a branch
 or commit as argument, the following step would be to check it out. We then build again,
 and save the image to storage.
+
+
+### 3. More Complicated Builds
+
+If you are working on a server environment, you may not want to
+build from the present working directory (the active directory of
+your application) and you might not want to rely on the environment 
+for discovering variables. In this case, you have other options.
+
+#### Client Envars
+
+Before instantiating a client, you can provide as many of the
+environment variables and provide them in a dictionary.
+
+```python
+# Provide all envars directly to client instead of environment
+context = {'GOOGLE_APPLICATION_CREDENTIALS': GOOGLE_APPLICATION_CREDENTIALS,
+           'SREGISTRY_GOOGLE_PROJECT': settings.SREGISTRY_GOOGLE_PROJECT}
+```
+
+And then provide them to the get_client function:
+
+```python
+from sregistry.main.google_build.client import get_client
+client = get_client(debug=True, **context)
+```
+
+#### Working Directory
+
+If you web application runs from a particular context that you cannot
+change, a server using the client will not work properly 
+if you change directory to where the recipe is. For this reason,
+you can supply a working directory. For this working directory,
+we will remove it from the full paths (so the Google Build
+will happen relative to it). By default, the working directory
+is not set, indicative that the build context is the present working
+directory.
+
+```bash
+
+```
+
 
 
 ## Pull and Search

--- a/docs/pages/clients/google-build.md
+++ b/docs/pages/clients/google-build.md
@@ -422,7 +422,7 @@ environment variables and provide them in a dictionary.
 ```python
 # Provide all envars directly to client instead of environment
 context = {'GOOGLE_APPLICATION_CREDENTIALS': GOOGLE_APPLICATION_CREDENTIALS,
-           'SREGISTRY_GOOGLE_PROJECT': settings.SREGISTRY_GOOGLE_PROJECT}
+           'SREGISTRY_GOOGLE_PROJECT': SREGISTRY_GOOGLE_PROJECT}
 ```
 
 And then provide them to the get_client function:
@@ -431,22 +431,6 @@ And then provide them to the get_client function:
 from sregistry.main.google_build.client import get_client
 client = get_client(debug=True, **context)
 ```
-
-#### Working Directory
-
-If you web application runs from a particular context that you cannot
-change, a server using the client will not work properly 
-if you change directory to where the recipe is. For this reason,
-you can supply a working directory. For this working directory,
-we will remove it from the full paths (so the Google Build
-will happen relative to it). By default, the working directory
-is not set, indicative that the build context is the present working
-directory.
-
-```bash
-
-```
-
 
 
 ## Pull and Search

--- a/sregistry/client/build.py
+++ b/sregistry/client/build.py
@@ -37,7 +37,7 @@ def main(args, parser, extra):
         response = run_registry_build(cli, args, extra)
 
     # If the client wants to preview, the config is returned
-    if args.preview is True:
+    if args.preview:
         print(json.dumps(response, indent=4, sort_keys=True))
 
 
@@ -68,7 +68,8 @@ def run_google_build(cli, args):
                              preview=args.preview)
 
     # Print output to the console
-    print_output(response, args.outfile)
+    if not args.preview:
+        print_output(response, args.outfile)
     return response
 
 
@@ -152,22 +153,23 @@ def print_output(response, output_file=None):
 
     '''
     # If successful built, show container uri
-    if response['status'] == 'SUCCESS':
-        bucket = response['artifacts']['objects']['location']
-        obj = response['artifacts']['objects']['paths'][0]
-        bot.custom("MD5HASH", response['file_hash'], 'CYAN')
-        bot.custom("SIZE", response['size'], 'CYAN')
-        bot.custom(response['status'], bucket + obj , 'CYAN')
-    else:
-        bot.custom(response['status'], 'see logs for details', 'CYAN')
+    if "status" in response:
+        if response['status'] == 'SUCCESS':
+            bucket = response['artifacts']['objects']['location']
+            obj = response['artifacts']['objects']['paths'][0]
+            bot.custom("MD5HASH", response['file_hash'], 'CYAN')
+            bot.custom("SIZE", response['size'], 'CYAN')
+            bot.custom(response['status'], bucket + obj , 'CYAN')
+        else:
+            bot.custom(response['status'], 'see logs for details', 'CYAN')
 
-    # Show the logs no matter what
-    bot.custom("LOGS", response['logUrl'], 'CYAN')
+        # Show the logs no matter what
+        bot.custom("LOGS", response['logUrl'], 'CYAN')
 
-    # Did the user make the container public?
-    if "public_url" in response:
-        bot.custom('URL', response['public_url'], 'CYAN')
-
+        # Did the user make the container public?
+        if "public_url" in response:
+            bot.custom('URL', response['public_url'], 'CYAN')
+  
     # Does the user also need writing to an output file?
     if output_file is not None:    
         with open(output_file, 'w') as filey:

--- a/sregistry/client/build.py
+++ b/sregistry/client/build.py
@@ -133,7 +133,7 @@ def run_registry_build(cli, args, extra):
 
     recipe = args.commands.pop(0)
     response = cli.build(name=args.name,
-                         path=recipe,
+                         recipe=recipe,
                          extra=extra)
 
     # Print output to the console

--- a/sregistry/main/base/http.py
+++ b/sregistry/main/base/http.py
@@ -210,8 +210,7 @@ def stream(self, url,
         retry: should the client retry? (intended for use after token refresh)
                by default we retry once after token refresh, then fail.
     '''
-
-    bot.debug("GET %s" %url)
+    bot.debug("GET %s" % url)
 
     # Ensure headers are present, update if not
     if headers is None:

--- a/sregistry/main/google_build/build.py
+++ b/sregistry/main/google_build/build.py
@@ -184,7 +184,7 @@ def build_repo(self,
 
     # First preference to command line, then recipe tag
     _, tag = os.path.splitext(recipe)
-    tag = names.get('tag', tag).strip('.')
+    tag = (tag or names.get('tag')).strip('.')
 
     # Update the tag, if recipe provides one
     names = parse_image_name(remove_uri(repo), tag=tag)

--- a/sregistry/main/registry/build.py
+++ b/sregistry/main/registry/build.py
@@ -25,11 +25,11 @@ import requests
 import os
 
 
-def build(self, path, name, extra=None):
+def build(self, recipe, name, extra=None):
     '''push a recipe file to Singularity Registry server for a Google
        Cloud (or similar) build
     '''
-    path = os.path.abspath(path)
+    path = os.path.abspath(recipe)
     bot.debug("BUILD %s" % path)
 
     if extra is None:

--- a/sregistry/main/registry/pull.py
+++ b/sregistry/main/registry/pull.py
@@ -20,19 +20,19 @@ import os
 def pull(self, images, file_name=None, save=True, **kwargs):
     '''pull an image from a singularity registry
  
-    Parameters
-    ==========
-    images: refers to the uri given by the user to pull in the format
-    <collection>/<namespace>. You should have an API that is able to 
-    retrieve a container based on parsing this uri.
-    file_name: the user's requested name for the file. It can 
-               optionally be None if the user wants a default.
-    save: if True, you should save the container to the database
-          using self.add()
+        Parameters
+        ==========
+        images: refers to the uri given by the user to pull in the format
+        <collection>/<namespace>. You should have an API that is able to 
+        retrieve a container based on parsing this uri.
+        file_name: the user's requested name for the file. It can 
+                   optionally be None if the user wants a default.
+        save: if True, you should save the container to the database
+              using self.add()
     
-    Returns
-    =======
-    finished: a single container path, or list of paths
+        Returns
+        =======
+        finished: a single container path, or list of paths
     '''
 
     if not isinstance(images,list):
@@ -41,7 +41,7 @@ def pull(self, images, file_name=None, save=True, **kwargs):
     # Interaction with a registry requires secrets
     self.require_secrets()
 
-    bot.debug('Execution of PULL for %s images' %len(images))
+    bot.debug('Execution of PULL for %s images' % len(images))
 
     finished = []
     for image in images:
@@ -76,11 +76,11 @@ def pull(self, images, file_name=None, save=True, **kwargs):
         if isinstance(manifest, Response):
 
             # Requires token
-            if manifest.status_code == 403:
+            if manifest.status_code in [403, 401]:
 
                 SREGISTRY_EVENT = self.authorize(request_type="pull",
                                                  names=q)
-                headers = {'Authorization': SREGISTRY_EVENT }
+                headers = {'Authorization': SREGISTRY_EVENT}
                 self._update_headers(headers)
                 manifest = self._get(url)
 
@@ -105,6 +105,9 @@ def pull(self, images, file_name=None, save=True, **kwargs):
 
             if file_name is None:
                 file_name = q['storage'].replace('/','-')
+
+            # Clear headers of previous token
+            self._reset_headers()
     
             # Show progress if not quiet
             image_file = self.download(url=manifest['image'],

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 '''
 
-__version__ = "0.2.2"
+__version__ = "0.2.21"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'


### PR DESCRIPTION
This will fix a subtle issue that if you are running build from python, and you add a recipe from a directory not in the PWD, the builder will fail because the recipe is out of his context.