### PR TITLE
search doesnt honor uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.0.x)
+ - Fixing sregistry search to honor a URI (0.2.22)
  - adding ability to specify working_dir for Google Cloud Build (0.2.21)
  - finalizing registry Google Cloud Builder (0.2.20)
  - adding sregistry build to push recipes for Google Cloud (or other) builder (0.2.19)

--- a/docs/pages/clients/google-build.md
+++ b/docs/pages/clients/google-build.md
@@ -72,7 +72,9 @@ Let's get off to a running start and build! We have two options for building:
  3. More Complicated Builds
 
 The second is recommended, as it is more reproducible, but there are use cases for
-both.
+both. You can continue reading below, or watch the tutorial here:
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/Mm0Hs6NTvMc" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ### 1. Build from a Local Recipe
 

--- a/sregistry/client/build.py
+++ b/sregistry/client/build.py
@@ -57,7 +57,8 @@ def run_google_build(cli, args):
 
     # If Github.com is provided in the name, we are doing a GitHub build
     if re.search("github.com|gitlab.com", args.name):
-        response = cli.build_repo(repo=args.name,
+        name = args.name.replace('google-build://', '')
+        response = cli.build_repo(repo=name,
                                   recipe=recipe,
                                   preview=args.preview)
 

--- a/sregistry/client/search.py
+++ b/sregistry/client/search.py
@@ -9,19 +9,23 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 '''
 
 from sregistry.logger import bot
+from sregistry.utils import remove_uri
 
 def main(args, parser, extra):
 
     from sregistry.main import get_client
 
     for query in args.query:
+        original = query
+        query = remove_uri(query)
+
         if query in ['','*']:
             query = None
 
         try:
-            cli = get_client(query, quiet=args.quiet)
+            cli = get_client(original, quiet=args.quiet)
             cli.announce(args.command)
-            cli.search(query=query, args=args)
+            cli.search(query, args=args)
         except NotImplementedError:
             msg = "search is not implemented for %s. Why don't you add it?"
             bot.exit(msg % cli.client_name)

--- a/sregistry/main/google_build/query.py
+++ b/sregistry/main/google_build/query.py
@@ -18,11 +18,9 @@ def search(self, query=None, args=None):
        query is provided, all images in the bucket are listed that have type
        "container" in the metadata and client "sregistry"
     '''
-
     if query is not None:
         return self._container_query(query)
     return self._search_all()
-
 
 
 def list_containers(self):

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 '''
 
-__version__ = "0.2.21"
+__version__ = "0.2.22"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'


### PR DESCRIPTION
When we search, we should be able to provide a uri like:

```bash
$ sregistry search google-build://
```
This isn't currently honored.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>