### PR TITLE
Add missing type: container tag with upload to Google Storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.2.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.2.x)
+ - Metadata must include type of container (0.2.30)
+   - accounting for Singularity 3.x bugs with metadata fields 
  - Fixing bug with setting docker base to None with super (0.2.29)
  - sregistry.main.registry: use env variables for authorization (0.2.28)
    - docs.pages.clients.registry: add delete docs

--- a/sregistry/main/base/__init__.py
+++ b/sregistry/main/base/__init__.py
@@ -27,9 +27,7 @@ from sregistry.main.base.http import (
     stream_response, verify
 )
 
-from sregistry.main.base.inspect import (
-    get_metadata
-)
+from sregistry.main.base.inspect import get_metadata
 
 from sregistry.main.base.settings import (
     get_setting,

--- a/sregistry/main/base/inspect.py
+++ b/sregistry/main/base/inspect.py
@@ -80,7 +80,7 @@ def get_metadata(self, image_file, names=None):
 
                 # Flatten labels
                 if "attributes" in metadata:
-                    if "labels" in metadata['attributes']
+                    if "labels" in metadata['attributes']:
                         metadata.update(metadata['attributes']['labels'])
                     del metadata['attributes']
 

--- a/sregistry/main/base/inspect.py
+++ b/sregistry/main/base/inspect.py
@@ -72,9 +72,24 @@ def get_metadata(self, image_file, names=None):
         if updates is not None:
             try:
                 updates = json.loads(updates)
+
+                # Singularity 3.x bug with missing top level
+                if "data" in updates:
+                    updates = updates['data']
                 metadata.update(updates)
+
+                # Flatten labels
+                if "attributes" in metadata:
+                    if "labels" in metadata['attributes']
+                        metadata.update(metadata['attributes']['labels'])
+                    del metadata['attributes']
+
             except:
                 pass
 
     metadata.update(names)
+
+    # Add the type to the container
+    metadata['type'] = 'container'
+
     return metadata

--- a/sregistry/main/google_build/push.py
+++ b/sregistry/main/google_build/push.py
@@ -42,9 +42,6 @@ def push(self, path, name, tag=None):
 
     # Update metadata with names
     metadata = self.get_metadata(path, names=names)
-    if "data" in metadata:
-        metadata = metadata['data']
-    metadata.update(names)
 
     manifest = self._upload(source=path, 
                             destination=names['storage'],

--- a/sregistry/main/google_drive/push.py
+++ b/sregistry/main/google_drive/push.py
@@ -47,10 +47,6 @@ def push(self, path, name, tag=None):
 
     # Update metadata with names, flatten to only include labels
     metadata = self.get_metadata(path, names=names)
-    metadata = metadata['data']
-    metadata.update(names)
-    metadata.update(metadata['attributes']['labels'])
-    del metadata['attributes']
 
     file_metadata = {
         'name': names['storage'],

--- a/sregistry/main/google_storage/push.py
+++ b/sregistry/main/google_storage/push.py
@@ -23,9 +23,11 @@ import os
 def push(self, path, name, tag=None):
     '''push an image to Google Cloud Storage, meaning uploading it
     
-    path: should correspond to an absolte image path (or derive it)
-    name: should be the complete uri that the user has requested to push.
-    tag: should correspond with an image tag. This is provided to mirror Docker
+       Parameters
+       ==========
+       path: should correspond to an absolte image path (or derive it)
+       name: should be the complete uri that the user has requested to push.
+       tag: should correspond with an image tag. This is provided to mirror Docker
     '''
     path = os.path.abspath(path)
     bot.debug("PUSH %s" % path)
@@ -42,9 +44,6 @@ def push(self, path, name, tag=None):
 
     # Update metadata with names
     metadata = self.get_metadata(path, names=names)
-    if "data" in metadata:
-        metadata = metadata['data']
-    metadata.update(names)
 
     manifest = self._upload(source=path, 
                             destination=names['storage'],

--- a/sregistry/main/s3/push.py
+++ b/sregistry/main/s3/push.py
@@ -35,7 +35,8 @@ def push(self, path, name, tag=None):
     # *important* bug in boto3 will return these capitalized
     # see https://github.com/boto/boto3/issues/1709
     metadata = {'sizemb': "%s" % image_size,
-                'client': 'sregistry'}
+                'client': 'sregistry',
+                'type': 'container'}
 
     ExtraArgs = {"Metadata": metadata}
 

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 '''
 
-__version__ = "0.2.29"
+__version__ = "0.2.30"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'sregistry'


### PR DESCRIPTION
This will close #239. The same method is used for Drive and the build client, so it's updated there as well.