### PR TITLE
Fix google backend pull exit return values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.2.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.2.x)
+ - Fix google backend pull exit return values (0.2.34)
+   - Pin httplib2 to 0.15.0 for all google backends
  - adding black for lint formatting (0.2.33)
  - Don't allow user to forget credentials and base registry client (0.2.32)
  - Adding missing dependency for Google Build (0.2.31)

--- a/sregistry/main/google_build/pull.py
+++ b/sregistry/main/google_build/pull.py
@@ -11,7 +11,6 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from sregistry.logger import bot
 from sregistry.utils import parse_image_name, remove_uri
 import os
-import sys
 
 
 def pull(self, images, file_name=None, save=True, **kwargs):

--- a/sregistry/main/google_build/pull.py
+++ b/sregistry/main/google_build/pull.py
@@ -48,8 +48,7 @@ def pull(self, images, file_name=None, save=True, **kwargs):
         matches = self._container_query(q["uri"], quiet=True)
 
         if len(matches) == 0:
-            bot.info("No matching containers found.")
-            sys.exit(0)
+            bot.exit("No matching containers found.")
 
         # If the user didn't provide a file, make one based on the names
         if file_name is None:

--- a/sregistry/main/google_drive/pull.py
+++ b/sregistry/main/google_drive/pull.py
@@ -12,7 +12,6 @@ from sregistry.logger import bot, ProgressBar
 from sregistry.utils import parse_image_name, remove_uri
 from googleapiclient.http import MediaIoBaseDownload
 import os
-import sys
 
 
 def pull(self, images, file_name=None, save=True, **kwargs):

--- a/sregistry/main/google_drive/pull.py
+++ b/sregistry/main/google_drive/pull.py
@@ -49,8 +49,7 @@ def pull(self, images, file_name=None, save=True, **kwargs):
         matches = self._container_query(q["uri"], quiet=True)
 
         if len(matches) == 0:
-            bot.info("No matching containers found.")
-            sys.exit(0)
+            bot.exit("No matching containers found.")
 
         # If the user didn't provide a file, make one based on the names
         if file_name is None:

--- a/sregistry/main/google_storage/pull.py
+++ b/sregistry/main/google_storage/pull.py
@@ -11,7 +11,6 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from sregistry.logger import bot
 from sregistry.utils import parse_image_name, remove_uri
 import os
-import sys
 
 
 def pull(self, images, file_name=None, save=True, **kwargs):

--- a/sregistry/main/google_storage/pull.py
+++ b/sregistry/main/google_storage/pull.py
@@ -48,8 +48,7 @@ def pull(self, images, file_name=None, save=True, **kwargs):
         matches = self._container_query(q["uri"], quiet=True)
 
         if len(matches) == 0:
-            bot.info("No matching containers found.")
-            sys.exit(0)
+            bot.exit("No matching containers found.")
 
         # If the user didn't provide a file, make one based on the names
         if file_name is None:

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.2.33"
+__version__ = "0.2.34"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "sregistry"

--- a/sregistry/version.py
+++ b/sregistry/version.py
@@ -57,6 +57,7 @@ INSTALL_BASIC_GOOGLE_STORAGE = (
     ("google-cloud-storage", {"min_version": "1.4.0"}),
     ("google-api-python-client", {"min_version": "1.6.4"}),
     ("retrying", {"min_version": "1.3.3"}),
+    ("httplib2", {"exact_version": "0.15.0"}),
 )
 
 INSTALL_BASIC_GOOGLE_BUILD = (
@@ -64,17 +65,20 @@ INSTALL_BASIC_GOOGLE_BUILD = (
     ("google-cloud-storage", {"min_version": "1.4.0"}),
     ("google-api-python-client", {"min_version": "1.6.4"}),
     ("retrying", {"min_version": "1.3.3"}),
+    ("httplib2", {"exact_version": "0.15.0"}),
 )
 
 INSTALL_BASIC_GOOGLE_DRIVE = (
     ("google-api-python-client", {"min_version": "1.6.4"}),
     ("oauth2client", {"min_version": "3.0"}),
+    ("httplib2", {"exact_version": "0.15.0"}),
 )
 
 INSTALL_BASIC_GOOGLE_COMPUTE = (
     ("oauth2client", {"min_version": "3.0"}),
     ("google-api-python-client", {"min_version": "1.6.4"}),
     ("google-cloud-storage", {"min_version": "1.4.0"}),
+    ("httplib2", {"exact_version": "0.15.0"}),
 )
 
 INSTALL_BASIC_S3 = (("boto3", {"min_version": "1.7.83"}),)
@@ -131,6 +135,7 @@ INSTALL_REQUIRES_GOOGLE_STORAGE = (
     ("google-api-python-client", {"min_version": "1.6.4"}),
     ("retrying", {"exact_version": "1.3.3"}),
     ("sqlalchemy", {"min_version": None}),
+    ("httplib2", {"exact_version": "0.15.0"}),
 )
 
 INSTALL_REQUIRES_GOOGLE_BUILD = (
@@ -139,12 +144,14 @@ INSTALL_REQUIRES_GOOGLE_BUILD = (
     ("google-api-python-client", {"min_version": "1.6.4"}),
     ("retrying", {"exact_version": "1.3.3"}),
     ("sqlalchemy", {"min_version": None}),
+    ("httplib2", {"exact_version": "0.15.0"}),
 )
 
 INSTALL_REQUIRES_GOOGLE_DRIVE = (
     ("oauth2client", {"min_version": "3.0"}),
     ("sqlalchemy", {"min_version": None}),
     ("google-api-python-client", {"min_version": "1.6.4"}),
+    ("httplib2", {"exact_version": "0.15.0"}),
 )
 
 INSTALL_REQUIRES_GOOGLE_COMPUTE = (
@@ -152,6 +159,7 @@ INSTALL_REQUIRES_GOOGLE_COMPUTE = (
     ("sqlalchemy", {"min_version": None}),
     ("google-api-python-client", {"min_version": "1.6.4"}),
     ("google-cloud-storage", {"min_version": "1.4.0"}),
+    ("httplib2", {"exact_version": "0.15.0"}),
 )
 
 INSTALL_REQUIRES_S3 = (


### PR DESCRIPTION
This commit ensures that the google backends pull methods result in the program exiting with return code 1 instead of 0, when the image could not be found.
I find this a useful feature to exploit in scripts...